### PR TITLE
base64 decode of username if basic authentification

### DIFF
--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentResource.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentResource.xtend
@@ -16,6 +16,8 @@ import javax.ws.rs.core.Response
 
 import static javax.ws.rs.core.Response.Status.*
 import static javax.ws.rs.core.Response.status
+import java.util.Base64
+import java.nio.charset.Charset
 
 @Path("/documents/{resourcePath:.*}")
 @Produces(MediaType.TEXT_PLAIN)
@@ -67,7 +69,15 @@ class DocumentResource {
 
 	// currently dummy implementation to get user from header authorization
 	private def String getUserName(HttpHeaders headers) {
-		return headers.getHeaderString('Authorization').split(':').head
+		val authorization = headers.getHeaderString('Authorization')
+		var credential = ""
+		if (authorization.startsWith("Basic")) {
+			val base64Credential = authorization.replaceFirst("^Basic ", "")
+			credential = new String(Base64.decoder.decode(base64Credential), Charset.forName("UTF-8"))
+		} else {
+			credential = authorization
+		}
+		return (credential).split(':').head
 	}
 
 }


### PR DESCRIPTION
If basic authentification is used the username and password is bas64 encoded. In this case the `getUsername ` methode returns the base64 decoded username.