### PR TITLE
Use only field injection

### DIFF
--- a/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/IndexServiceClient.xtend
+++ b/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/IndexServiceClient.xtend
@@ -2,6 +2,7 @@ package org.testeditor.web.backend.xtext.index
 
 import com.google.common.base.Predicate
 import com.google.inject.Inject
+import com.google.inject.Provider
 import com.google.inject.name.Named
 import java.net.URI
 import java.util.List
@@ -9,6 +10,7 @@ import java.util.Map
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs.client.Client
 import javax.ws.rs.client.Entity
+import javax.ws.rs.client.WebTarget
 import javax.ws.rs.core.GenericType
 import javax.ws.rs.core.MediaType
 import org.eclipse.emf.ecore.EReference
@@ -24,8 +26,6 @@ import org.slf4j.LoggerFactory
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION
 
 import static extension java.util.Objects.requireNonNull
-import com.google.inject.Provider
-import javax.ws.rs.client.WebTarget
 
 class IndexServiceClient implements IGlobalScopeProvider {
 
@@ -36,7 +36,8 @@ class IndexServiceClient implements IGlobalScopeProvider {
 	Client client
 	
 	@Inject
-	@Named("index-service-base-URI") URI baseURI
+	@Named("index-service-base-URI")
+	URI baseURI
 	
 	@Inject
 	Provider<HttpServletRequest> requestProvider

--- a/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/IndexServiceClient.xtend
+++ b/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/IndexServiceClient.xtend
@@ -31,23 +31,16 @@ class IndexServiceClient implements IGlobalScopeProvider {
 
 	static val logger = LoggerFactory.getLogger(IndexServiceClient)
 	
-
-	val Client client
-	val URI baseURI
-	
-	var Provider<HttpServletRequest> requestProvider
-
 	@Inject
-	new(@Named("index-service-client") Client client, @Named("index-service-base-URI") URI target,
-		Provider<HttpServletRequest> request) {
-		client.requireNonNull("client must not be null")
-		target.requireNonNull("URI must not be null")
-		request.requireNonNull("Context request must not be null")
+	@Named("index-service-client") 
+	Client client
+	
+	@Inject
+	@Named("index-service-base-URI") URI baseURI
+	
+	@Inject
+	Provider<HttpServletRequest> requestProvider
 
-		this.client = client
-		this.baseURI = target
-		this.requestProvider = request
-	}
 	
 	override getScope(Resource context, EReference reference, Predicate<IEObjectDescription> filter) {
 		

--- a/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientIntegrationTest.xtend
+++ b/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientIntegrationTest.xtend
@@ -27,6 +27,8 @@ import org.eclipse.xtext.resource.EObjectDescription
 import org.eclipse.xtext.resource.IEObjectDescription
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.resource.XtextResourceSet
+import org.eclipse.xtext.web.server.generator.DefaultContentTypeProvider
+import org.eclipse.xtext.web.server.generator.IContentTypeProvider
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule

--- a/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientIntegrationTest.xtend
+++ b/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientIntegrationTest.xtend
@@ -119,7 +119,6 @@ class IndexServiceClientIntegrationTest {
 		when(contextRequest.getHeader(AUTHORIZATION)).thenReturn(AUTH_HEADER)
 
 		val Module testBindings = [
-			// bind(IGlobalScopeProvider).to(IndexServiceClient)
 			bind(Client).annotatedWith(Names.named("index-service-client")).toInstance(client)
 			bind(URI).annotatedWith(Names.named("index-service-base-URI")).toInstance(baseURI)
 			bind(HttpServletRequest).toProvider[contextRequest]

--- a/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientIntegrationTest.xtend
+++ b/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientIntegrationTest.xtend
@@ -2,6 +2,7 @@ package org.testeditor.web.backend.xtext.index
 
 import com.codahale.metrics.Metric
 import com.fasterxml.jackson.databind.module.SimpleModule
+import com.google.inject.Guice
 import com.google.inject.Module
 import com.google.inject.name.Names
 import com.squarespace.jersey2.guice.JerseyGuiceUtils
@@ -11,6 +12,7 @@ import io.dropwizard.setup.Environment
 import io.dropwizard.testing.ResourceHelpers
 import io.dropwizard.testing.junit.DropwizardAppRule
 import io.dropwizard.testing.junit.DropwizardClientRule
+import java.net.URI
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs.Consumes
 import javax.ws.rs.POST
@@ -20,15 +22,12 @@ import javax.ws.rs.QueryParam
 import javax.ws.rs.client.Client
 import javax.ws.rs.core.Context
 import javax.ws.rs.core.Response
-import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.util.EcoreUtil
 import org.eclipse.xtext.naming.QualifiedName
 import org.eclipse.xtext.resource.EObjectDescription
 import org.eclipse.xtext.resource.IEObjectDescription
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.resource.XtextResourceSet
-import org.eclipse.xtext.web.server.generator.DefaultContentTypeProvider
-import org.eclipse.xtext.web.server.generator.IContentTypeProvider
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
@@ -45,9 +44,7 @@ import org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerializer
 
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION
 import static org.assertj.core.api.Assertions.assertThat
-import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import com.google.inject.Guice
 
 class IndexServiceClientIntegrationTest {
 
@@ -91,7 +88,8 @@ class IndexServiceClientIntegrationTest {
 		val client = mockedIndexServiceClient
 
 		val resource = new XtextResourceSet().getResource(
-			URI.createURI(ResourceHelpers.resourceFilePath("pack/MacroLib.tml")), true) as XtextResource
+			org.eclipse.emf.common.util.URI.createURI(ResourceHelpers.resourceFilePath("pack/MacroLib.tml")),
+			true) as XtextResource
 		val reference = TclPackage.eINSTANCE.macroTestStepContext_MacroCollection
 
 		// when
@@ -116,14 +114,14 @@ class IndexServiceClientIntegrationTest {
 
 	private def getMockedIndexServiceClient() {
 		val client = new JerseyClientBuilder(dropwizardClient.environment).build(TEST_CLIENT_NAME)
-		val baseURI = java.net.URI.create('''«dropwizardServer.baseUri»/xtext/index/global-scope''')
+		val baseURI = URI.create('''«dropwizardServer.baseUri»/xtext/index/global-scope''')
 		val contextRequest = mock(HttpServletRequest)
 		when(contextRequest.getHeader(AUTHORIZATION)).thenReturn(AUTH_HEADER)
 
 		val Module testBindings = [
 			// bind(IGlobalScopeProvider).to(IndexServiceClient)
 			bind(Client).annotatedWith(Names.named("index-service-client")).toInstance(client)
-			bind(java.net.URI).annotatedWith(Names.named("index-service-base-URI")).toInstance(baseURI)
+			bind(URI).annotatedWith(Names.named("index-service-base-URI")).toInstance(baseURI)
 			bind(HttpServletRequest).toProvider[contextRequest]
 		]
 

--- a/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientTest.xtend
+++ b/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientTest.xtend
@@ -185,11 +185,12 @@ class IndexServiceClientTest {
 	@Test
 	def void shouldFilterResults() {
 		// given
-		val filter = [IEObjectDescription description|description.name !== null && !description.name.empty]
+
+		val filter = [IEObjectDescription description | description.name !== null && !description.name.empty]
 		val validResultItem = mock(IEObjectDescription)
 		when(validResultItem.name).thenReturn(QualifiedName.create("VALID"))
 		when(validResultItem.EClass).thenReturn(XtextPackage.eINSTANCE.grammar)
-
+		
 		val invalidResultItem = mock(IEObjectDescription)
 		when(invalidResultItem.EClass).thenReturn(XtextPackage.eINSTANCE.grammar)
 

--- a/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientTest.xtend
+++ b/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientTest.xtend
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.*
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
 import com.google.inject.Provider
+import ch.qos.logback.classic.spi.ILoggingEvent
 
 @RunWith(MockitoJUnitRunner)
 class IndexServiceClientTest {
@@ -45,7 +46,7 @@ class IndexServiceClientTest {
 	static val AUTH_HEADER = "Bearer DUMMYTOKEN"
 
 	@Mock
-	var Appender logAppender
+	var Appender<ILoggingEvent> logAppender
 	var ArgumentCaptor<LoggingEvent> logCaptor
 
 	@Mock

--- a/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientTest.xtend
+++ b/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientTest.xtend
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION
 import static org.assertj.core.api.Assertions.*
 import static org.mockito.ArgumentMatchers.*
-import static org.mockito.Mockito.*
+import static extension org.mockito.Mockito.*
 import com.google.inject.Provider
 import ch.qos.logback.classic.spi.ILoggingEvent
 
@@ -51,6 +51,13 @@ class IndexServiceClientTest {
 
 	@Mock
 	var Client client
+	
+	//URI is a final class, which cannot be mocked by Mockito by default.
+	//Therefore, Mockito's inline-mockmaker was enabled by placing the file
+	//"org.mockito.plugins.MockMaker" in "src/test/resources/mockito-extensions",
+	//with content "mock-maker-inline".
+	//See https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#unmockable
+	//for documentation.
 	@Spy
 	var java.net.URI uri = java.net.URI.create("http://www.example.org")
 	@Mock
@@ -94,7 +101,7 @@ class IndexServiceClientTest {
 	@Test
 	def void shouldReturnNullScopeOnNullResourceSet() {
 		// given
-		val resource = mock(XtextResource)
+		val resource = XtextResource.mock
 		when(resource.resourceSet).thenReturn(null)
 
 		// when
@@ -114,13 +121,13 @@ class IndexServiceClientTest {
 	@Test
 	def void shouldReturnServerResponseOnMissingSerializer() {
 		// given
-		val expected = mock(IEObjectDescription)
+		val expected = IEObjectDescription.mock
 		when(expected.EClass).thenReturn(XtextPackage.eINSTANCE.grammar)
 
 		setupMocksWithAuthHeader(null, #[expected])
-		val resource = mock(XtextResource)
-		when(resource.resourceSet).thenReturn(mock(XtextResourceSet))
-		when(resource.URI).thenReturn(mock(URI))
+		val resource = XtextResource.mock
+		when(resource.resourceSet).thenReturn(XtextResourceSet.mock)
+		when(resource.URI).thenReturn(URI.mock)
 
 		val reference = XtextPackage.eINSTANCE.grammar_UsedGrammars
 
@@ -135,11 +142,11 @@ class IndexServiceClientTest {
 	@Test
 	def void shouldReturnServerResponseOnNormalInvocation() {
 		// given
-		val expected = mock(IEObjectDescription)
+		val expected = IEObjectDescription.mock
 		when(expected.EClass).thenReturn(XtextPackage.eINSTANCE.grammar)
 
 		setupMocksWithAuthHeader("Sample content", #[expected])
-		val resource = mockedResource("Sample content", new BasicEList(#[mock(EObject)]))
+		val resource = mockedResource("Sample content", new BasicEList(#[EObject.mock]))
 
 		val reference = XtextPackage.eINSTANCE.grammar_UsedGrammars
 
@@ -155,15 +162,15 @@ class IndexServiceClientTest {
 	def void shouldFilterResults() {
 		// given
 		val filter = [IEObjectDescription description|description.name !== null && !description.name.empty]
-		val validResultItem = mock(IEObjectDescription)
+		val validResultItem = IEObjectDescription.mock
 		when(validResultItem.name).thenReturn(QualifiedName.create("VALID"))
 		when(validResultItem.EClass).thenReturn(XtextPackage.eINSTANCE.grammar)
 
-		val invalidResultItem = mock(IEObjectDescription)
+		val invalidResultItem = IEObjectDescription.mock
 		when(invalidResultItem.EClass).thenReturn(XtextPackage.eINSTANCE.grammar)
 
 		setupMocksWithAuthHeader("Sample content", #[validResultItem, invalidResultItem])
-		val resource = mockedResource("Sample content", new BasicEList(#[mock(EObject)]))
+		val resource = mockedResource("Sample content", new BasicEList(#[EObject.mock]))
 
 		val reference = XtextPackage.eINSTANCE.grammar_UsedGrammars
 
@@ -183,7 +190,7 @@ class IndexServiceClientTest {
 	@Test
 	def void shouldReturnServerResponseOnEmptyResource() {
 		// given
-		val expected = mock(IEObjectDescription)
+		val expected = IEObjectDescription.mock
 		when(expected.EClass).thenReturn(XtextPackage.eINSTANCE.grammar)
 		val messageBody = null
 		val resourceContent = null
@@ -202,8 +209,8 @@ class IndexServiceClientTest {
 	@Test
 	def void shouldRaiseExceptionOnNullReference() {
 		// given
-		val resource = mock(XtextResource)
-		when(resource.resourceSet).thenReturn(mock(XtextResourceSet))
+		val resource = XtextResource.mock
+		when(resource.resourceSet).thenReturn(XtextResourceSet.mock)
 
 		// when
 		val actualException = catchThrowable[unitUnderTest.getScope(resource, null, null)]
@@ -216,12 +223,12 @@ class IndexServiceClientTest {
 	@Test
 	def void shouldWarnAboutBogusResponses() {
 		// given
-		val resultingEObjectDescriptionMock = mock(IEObjectDescription)
+		val resultingEObjectDescriptionMock = IEObjectDescription.mock
 		// arbitrary EClass that does not match the one of the reference
 		when(resultingEObjectDescriptionMock.EClass).thenReturn(XtextPackage.eINSTANCE.condition)
 
 		setupMocksWithAuthHeader("Sample content", #[resultingEObjectDescriptionMock])
-		val resource = mockedResource("Sample content", new BasicEList(#[mock(EObject)]))
+		val resource = mockedResource("Sample content", new BasicEList(#[EObject.mock]))
 
 		val reference = XtextPackage.eINSTANCE.grammar_UsedGrammars
 
@@ -241,11 +248,11 @@ class IndexServiceClientTest {
 	@Test
 	def void shouldWarnAboutMissingContextRequest() {
 		// given
-		val resultingEObjectDescriptionMock = mock(IEObjectDescription)
+		val resultingEObjectDescriptionMock = IEObjectDescription.mock
 		when(resultingEObjectDescriptionMock.EClass).thenReturn(XtextPackage.eINSTANCE.grammar)
 
 		setupMocksWithoutRequest("Sample content", #[resultingEObjectDescriptionMock])
-		val resource = mockedResource("Sample content", new BasicEList(#[mock(EObject)]))
+		val resource = mockedResource("Sample content", new BasicEList(#[EObject.mock]))
 
 		val reference = XtextPackage.eINSTANCE.grammar_UsedGrammars
 
@@ -265,11 +272,11 @@ class IndexServiceClientTest {
 	@Test
 	def void shouldWarnAboutMissingAuthenticationHeader() {
 		// given
-		val resultingEObjectDescriptionMock = mock(IEObjectDescription)
+		val resultingEObjectDescriptionMock = IEObjectDescription.mock
 		when(resultingEObjectDescriptionMock.EClass).thenReturn(XtextPackage.eINSTANCE.grammar)
 
 		setupMocks("Sample content", #[resultingEObjectDescriptionMock])
-		val resource = mockedResource("Sample content", new BasicEList(#[mock(EObject)]))
+		val resource = mockedResource("Sample content", new BasicEList(#[EObject.mock]))
 
 		val reference = XtextPackage.eINSTANCE.grammar_UsedGrammars
 
@@ -296,8 +303,8 @@ class IndexServiceClientTest {
 	}
 
 	private def void setupMocksWithoutRequest(String payload, List<IEObjectDescription> resultingEObjectDescriptions) {
-		val target = mock(WebTarget)
-		val invocationBuilder = mock(Builder)
+		val target = WebTarget.mock
+		val invocationBuilder = Builder.mock
 		when(client.target(eq(uri))).thenReturn(target)
 		when(target.queryParam(any, any)).thenReturn(target)
 		when(target.request(anyString)).thenReturn(invocationBuilder)
@@ -307,12 +314,16 @@ class IndexServiceClientTest {
 		when(invocationBuilder.post(payloadMatcher, any(GenericType))).thenReturn(resultingEObjectDescriptions)
 	}
 
+	/**
+	 * returns an Xtext resource, whose serializer will return the specified
+	 * payload, and whose contents will be set to the provided list of EObjects
+	 * (both parameters may be null).
+	 */
 	private def mockedResource(String payload, EList<EObject> resourceContents) {
-		val resource = mock(XtextResource)
-		val serializer = mock(ISerializer)
-		when(resource.resourceSet).thenReturn(mock(XtextResourceSet))
-		when(resource.URI).thenReturn(mock(URI))
-
+		val serializer = ISerializer.mock
+		val resource = XtextResource.mock
+		when(resource.resourceSet).thenReturn(XtextResourceSet.mock)
+		when(resource.URI).thenReturn(URI.mock)
 		when(resource.serializer).thenReturn(serializer)
 		if(payload !== null) {
 			when(serializer.serialize(any)).thenReturn(payload)

--- a/org.testeditor.web.backend.xtext/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/org.testeditor.web.backend.xtext/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
`IndexServiceClient` now uses field injection instead of constructor injection. Consequently, there are no more null checks, so I also removed the corresponding tests.
For testing and mock injection with Mockito, I enabled the _inline mock maker_ (like [this](https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#unmockable)). Without it, final classes like `java.net.URI` cannot be mocked by Mockito, so I would have had to do the injection manually for testing, or modify the production code (e.g. by accepting a wrapper class around `URI`, or just a string).