### PR TITLE
add EObjectDescription (de-)serializers (to/from JSON)

### DIFF
--- a/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/TestEditorApplication.xtend
+++ b/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/TestEditorApplication.xtend
@@ -1,11 +1,13 @@
 package org.testeditor.web.backend.xtext
 
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.google.inject.Guice
 import com.google.inject.Injector
 import com.google.inject.Module
 import com.google.inject.name.Names
 import com.google.inject.util.Modules
 import io.dropwizard.client.JerseyClientBuilder
+import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
 import java.net.URI
 import javax.inject.Inject
@@ -14,6 +16,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.ws.rs.client.Client
 import org.eclipse.jetty.server.session.SessionHandler
 import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtext.resource.IEObjectDescription
 import org.eclipse.xtext.scoping.IGlobalScopeProvider
 import org.eclipse.xtext.util.Modules2
 import org.eclipse.xtext.web.server.generator.DefaultContentTypeProvider
@@ -26,6 +29,8 @@ import org.testeditor.tcl.dsl.ide.TclIdeModule
 import org.testeditor.tsl.dsl.TslRuntimeModule
 import org.testeditor.tsl.dsl.web.TslWebSetup
 import org.testeditor.web.backend.xtext.index.IndexServiceClient
+import org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionDeserializer
+import org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerializer
 import org.testeditor.web.dropwizard.xtext.XtextApplication
 import org.testeditor.web.dropwizard.xtext.XtextServiceResource
 
@@ -42,6 +47,18 @@ class TestEditorApplication extends XtextApplication<TestEditorConfiguration> {
 
 	def static void main(String[] args) {
 		new TestEditorApplication().run(args)
+	}
+
+	override initialize(Bootstrap<TestEditorConfiguration> bootstrap) {
+		super.initialize(bootstrap)
+		registerCustomEObjectSerializer(bootstrap)
+	}
+
+	private def registerCustomEObjectSerializer(Bootstrap<TestEditorConfiguration> bootstrap) {
+		val customSerializerModule = new SimpleModule
+		customSerializerModule.addSerializer(IEObjectDescription, new EObjectDescriptionSerializer)
+		customSerializerModule.addDeserializer(IEObjectDescription, new EObjectDescriptionDeserializer)
+		bootstrap.objectMapper.registerModule(customSerializerModule)
 	}
 
 	override protected configureXtextServices(TestEditorConfiguration configuration, Environment environment) {

--- a/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/serialization/EObjectDescriptionDeserializer.xtend
+++ b/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/serialization/EObjectDescriptionDeserializer.xtend
@@ -1,4 +1,4 @@
-package org.testeditor.web.xtext.index.serialization
+package org.testeditor.web.backend.xtext.index.serialization
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonProcessingException
@@ -15,10 +15,10 @@ import org.eclipse.xtext.naming.QualifiedName
 import org.eclipse.xtext.resource.IEObjectDescription
 import org.eclipse.xtext.resource.persistence.SerializableEObjectDescription
 
-import static org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerialization.EOBJECT_URI__FIELD_NAME
-import static org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerialization.QUALIFIED_NAME__DELIMITER
-import static org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerialization.QUALIFIED_NAME__FIELD_NAME
-import static org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerialization.URI__FIELD_NAME
+import static org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerialization.EOBJECT_URI__FIELD_NAME
+import static org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerialization.QUALIFIED_NAME__DELIMITER
+import static org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerialization.QUALIFIED_NAME__FIELD_NAME
+import static org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerialization.URI__FIELD_NAME
 
 class EObjectDescriptionDeserializer extends StdDeserializer<IEObjectDescription> {
 

--- a/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/serialization/EObjectDescriptionSerialization.xtend
+++ b/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/serialization/EObjectDescriptionSerialization.xtend
@@ -1,4 +1,4 @@
-package org.testeditor.web.xtext.index.serialization
+package org.testeditor.web.backend.xtext.index.serialization
 
 class EObjectDescriptionSerialization {
 	public static val EOBJECT_URI__FIELD_NAME = "eObjectURI"

--- a/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/serialization/EObjectDescriptionSerializer.xtend
+++ b/org.testeditor.web.backend.xtext/src/main/java/org/testeditor/web/backend/xtext/index/serialization/EObjectDescriptionSerializer.xtend
@@ -1,4 +1,4 @@
-package org.testeditor.web.xtext.index.serialization
+package org.testeditor.web.backend.xtext.index.serialization
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonProcessingException
@@ -8,10 +8,10 @@ import java.io.IOException
 import org.eclipse.emf.ecore.util.EcoreUtil
 import org.eclipse.xtext.resource.IEObjectDescription
 
-import static org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerialization.EOBJECT_URI__FIELD_NAME
-import static org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerialization.QUALIFIED_NAME__DELIMITER
-import static org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerialization.QUALIFIED_NAME__FIELD_NAME
-import static org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerialization.URI__FIELD_NAME
+import static org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerialization.EOBJECT_URI__FIELD_NAME
+import static org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerialization.QUALIFIED_NAME__DELIMITER
+import static org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerialization.QUALIFIED_NAME__FIELD_NAME
+import static org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerialization.URI__FIELD_NAME
 
 class EObjectDescriptionSerializer extends StdSerializer<IEObjectDescription> {
 

--- a/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/AbstractXtextIntegrationTest.xtend
+++ b/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/AbstractXtextIntegrationTest.xtend
@@ -16,8 +16,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.testeditor.web.backend.xtext.TestEditorApplication
 import org.testeditor.web.backend.xtext.TestEditorConfiguration
-import org.testeditor.web.xtext.index.serialization.EObjectDescriptionDeserializer
-import org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerializer
+import org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionDeserializer
+import org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerializer
 
 import static io.dropwizard.testing.ConfigOverride.config
 
@@ -51,17 +51,17 @@ abstract class AbstractXtextIntegrationTest {
 	new() {
 		initializeRules
 	}
-	
+
 	def void initializeRules() {
 		dummyResource = new DummyGlobalScopeResource
 		ensureServiceLocatorPopulated
 		dropwizardIndexServerRule = new EagerDropwizardClientRule(dummyResource)
-		
+
 		dropwizardXtextClientRule = new DropwizardAppRule(TestEditorApplication,
 			ResourceHelpers.resourceFilePath('test-config.yml'),
 			#[config('indexServiceURL', '''«dropwizardIndexServerRule.baseUri»/xtext/index/global-scope''')])
 	}
-	
+
 	/**
 	 * Actually a client rule, but acts as the server (remote) for this test
 	 */

--- a/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientIntegrationTest.xtend
+++ b/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/IndexServiceClientIntegrationTest.xtend
@@ -29,8 +29,8 @@ import org.testeditor.tcl.dsl.TclStandaloneSetup
 import org.testeditor.tsl.dsl.web.TslWebSetup
 import org.testeditor.web.backend.xtext.TestEditorApplication
 import org.testeditor.web.backend.xtext.TestEditorConfiguration
-import org.testeditor.web.xtext.index.serialization.EObjectDescriptionDeserializer
-import org.testeditor.web.xtext.index.serialization.EObjectDescriptionSerializer
+import org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionDeserializer
+import org.testeditor.web.backend.xtext.index.serialization.EObjectDescriptionSerializer
 
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION
 import static org.assertj.core.api.Assertions.assertThat


### PR DESCRIPTION
**Contains code clones!** :worried: 
Much of this code is duplicated in xtext-index-service. The corresponding classes should be moved to a common utility module. They were already part of this project, but only as part of the test source set. 
