### PR TITLE
add test cases wrt DocumentProvider's expected Git interaction

### DIFF
--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/AbstractPersistenceIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/AbstractPersistenceIntegrationTest.xtend
@@ -6,7 +6,10 @@ import de.xtendutils.junit.AssertionHelper
 import io.dropwizard.testing.ResourceHelpers
 import io.dropwizard.testing.junit.DropwizardAppRule
 import javax.ws.rs.client.Invocation.Builder
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.junit.JGitTestUtil
 import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 
@@ -22,11 +25,15 @@ abstract class AbstractPersistenceIntegrationTest {
 		create
 	]
 
-	val configs = #[
-		config('server.applicationConnectors[0].port', '0'),
-		config('gitFSRoot', workspaceRoot.root.path),
-		config('projectRepoUrl', 'dummy')
-	]
+	public var TemporaryFolder remoteGitFolder
+
+	protected def getConfigs() {
+		#[
+			config('server.applicationConnectors[0].port', '0'),
+			config('gitFSRoot', workspaceRoot.root.path),
+			config('projectRepoUrl', setupRemoteGitRepository)
+		]
+	}
 
 	static def String createToken() {
 		val builder = JWT.create => [
@@ -47,9 +54,20 @@ abstract class AbstractPersistenceIntegrationTest {
 	protected extension val AssertionHelper = AssertionHelper.instance
 	protected val client = dropwizardAppRule.client
 
+	public def setupRemoteGitRepository() {
+		remoteGitFolder = new TemporaryFolder => [create]
+
+		val git = Git.init.setDirectory(remoteGitFolder.root).call
+		JGitTestUtil.writeTrashFile(git.repository, 'README.md', '# Readme')
+		git.add.addFilepattern("README.md").call
+		git.commit.setMessage("Initial commit").call
+		return "file://" + remoteGitFolder.root.absolutePath
+	}
+
 	@After
-	def void deleteTemporaryFolder() {
+	def void deleteTemporaryFolders() {
 		workspaceRoot.delete
+		remoteGitFolder.delete
 	}
 
 	protected def Builder createRequest(String relativePath) {

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.testeditor.web.backend.persistence.git.AbstractGitTest
 
 import static org.eclipse.jgit.diff.DiffEntry.ChangeType.*
+import java.io.File
 
 class DocumentProviderTest extends AbstractGitTest {
 
@@ -43,6 +44,20 @@ class DocumentProviderTest extends AbstractGitTest {
 
 		// then
 		remoteGit.assertSingleCommit(numberOfCommitsBefore, ADD, newFileName)
+	}
+	
+	//if files/folders are written before "git init", the latter will fail!
+	@Test
+	def void createInitsRepositoryBeforeWritingToWorkspace() {
+		// given
+		val pathToResourceToBeCreated = "some/parent/folder/example.tsl"
+		
+		// when
+		documentProvider.create(pathToResourceToBeCreated, "content")
+		
+		// then
+		workspaceProvider.workspace.assertFileExists(pathToResourceToBeCreated)
+		workspaceProvider.workspace.assertFileExists(".git")
 	}
 
 	@Test
@@ -140,5 +155,9 @@ class DocumentProviderTest extends AbstractGitTest {
 		git.getDiffEntries(git.lastCommit).exists [
 			changeType === expectedChangeType && newPath == path
 		].assertTrue('''Expected the following change: «expectedChangeType» «path», but found: «diffEntries.head.changeType» «diffEntries.head.newPath»''')
+	}
+	
+	private def assertFileExists(File parent, String path) {
+		new File(parent, path).exists.assertTrue
 	}
 }

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
@@ -2,9 +2,12 @@ package org.testeditor.web.backend.persistence
 
 import javax.inject.Inject
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.diff.DiffEntry.ChangeType
 import org.junit.Before
 import org.junit.Test
 import org.testeditor.web.backend.persistence.git.AbstractGitTest
+
+import static org.eclipse.jgit.diff.DiffEntry.ChangeType.*
 
 class DocumentProviderTest extends AbstractGitTest {
 
@@ -18,12 +21,124 @@ class DocumentProviderTest extends AbstractGitTest {
 
 	@Test
 	def void createCommitsNewFile() {
+		// given
+		val numberOfCommitsBefore = git.log.call.size
+
 		// when
 		documentProvider.create('a.txt', 'test')
 
 		// then
-		val commits = git.log.call
-		commits.assertSize(2)
+		val numberOfCommitsAfter = git.log.call.size
+		numberOfCommitsAfter.assertEquals(numberOfCommitsBefore + 1)
 	}
 
+	@Test
+	def void createPushesChanges() {
+		// given
+		val numberOfCommitsBefore = remoteGit.log.call.size
+		val newFileName = "theNewFile.txt"
+
+		// when
+		documentProvider.create(newFileName, 'test')
+
+		// then
+		remoteGit.assertSingleCommit(numberOfCommitsBefore, ADD, newFileName)
+	}
+
+	@Test
+	def void createOrUpdateNonExistingFileAddsAndCommits() {
+		// given
+		val nonExistingFile = "aFileThatHasNotYetBeenCreated.txt"
+		val numberOfCommitsBefore = git.log.call.size
+
+		// when
+		documentProvider.createOrUpdate(nonExistingFile, "Contents of new file")
+
+		// then
+		git.assertSingleCommit(numberOfCommitsBefore, ADD, nonExistingFile)
+	}
+
+	@Test
+	def void createOrUpdatePreExistingFileCommitsModifications() {
+		// given
+		val preExistingFile = preExistingFileInRepo
+		val numberOfCommitsBefore = git.log.call.size
+
+		// when
+		documentProvider.createOrUpdate(preExistingFile, "New contents of pre-existing file")
+
+		// then
+		git.assertSingleCommit(numberOfCommitsBefore, MODIFY, preExistingFile)
+	}
+	
+	@Test
+	def void saveCommitsChanges() {
+		// given
+		val existingFileName = preExistingFileInRepo
+		val numberOfCommitsBefore = git.log.call.size
+
+		// when
+		documentProvider.save(existingFileName, "Contents of pre-existing file")
+
+		// then
+		git.assertSingleCommit(numberOfCommitsBefore, MODIFY, existingFileName)
+	}
+
+	@Test
+	def void savePushesChanges() {
+		// given
+		val existingFileName = preExistingFileInRepo
+		val numberOfCommitsBefore = remoteGit.log.call.size
+
+		// when
+		documentProvider.save(existingFileName, "Contents of pre-existing file")
+
+		// then
+		remoteGit.assertSingleCommit(numberOfCommitsBefore, MODIFY, existingFileName)
+	}
+
+	@Test
+	def void deleteCommitsChanges() {
+		// given
+		val existingFileName = preExistingFileInRepo
+		val numberOfCommitsBefore = git.log.call.size
+
+		// when
+		documentProvider.delete(existingFileName)
+
+		// then
+		git.assertSingleCommit(numberOfCommitsBefore, DELETE, existingFileName)
+	}
+
+	@Test
+	def void deletePushesChanges() {
+		// given
+		val existingFileName = preExistingFileInRepo
+		val numberOfCommitsBefore = remoteGit.log.call.size
+
+		// when
+		documentProvider.delete(existingFileName)
+
+		// then
+		remoteGit.assertSingleCommit(numberOfCommitsBefore, DELETE, existingFileName)
+	}
+
+	private def preExistingFileInRepo() {
+		val filename = "preExistingFile.txt"
+		localGitRoot.newFile(filename).createNewFile
+		git.pull.call
+		git.add.addFilepattern(filename).call
+		git.commit.setMessage("set test preconditions").call
+		git.push.call
+		return filename
+	}
+
+	private def assertSingleCommit(Git git, int numberOfCommitsBefore, ChangeType expectedChangeType, String path) {
+		val numberOfCommitsAfter = git.log.call.size
+		numberOfCommitsAfter.assertEquals(numberOfCommitsBefore + 1)
+		val diffEntries = git.getDiffEntries(git.lastCommit)
+		git.getDiffEntries(git.lastCommit).exists [
+			changeType === expectedChangeType && newPath == path
+		].assertTrue('''Expected the following change: «expectedChangeType» «path», but found: «diffEntries.head.changeType» «diffEntries.head.newPath»''')
+	}
 }

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
@@ -23,13 +23,13 @@ class DocumentProviderTest extends AbstractGitTest {
 	def void createCommitsNewFile() {
 		// given
 		val numberOfCommitsBefore = git.log.call.size
+		val newFileName = "theNewFile.txt"
 
 		// when
-		documentProvider.create('a.txt', 'test')
+		documentProvider.create(newFileName, 'test')
 
 		// then
-		val numberOfCommitsAfter = git.log.call.size
-		numberOfCommitsAfter.assertEquals(numberOfCommitsBefore + 1)
+		git.assertSingleCommit(numberOfCommitsBefore, ADD, newFileName)
 	}
 
 	@Test
@@ -61,7 +61,7 @@ class DocumentProviderTest extends AbstractGitTest {
 	@Test
 	def void createOrUpdatePreExistingFileCommitsModifications() {
 		// given
-		val preExistingFile = preExistingFileInRepo
+		val preExistingFile = createAndPushFileToRepo
 		val numberOfCommitsBefore = git.log.call.size
 
 		// when
@@ -74,11 +74,11 @@ class DocumentProviderTest extends AbstractGitTest {
 	@Test
 	def void saveCommitsChanges() {
 		// given
-		val existingFileName = preExistingFileInRepo
+		val existingFileName = createAndPushFileToRepo
 		val numberOfCommitsBefore = git.log.call.size
 
 		// when
-		documentProvider.save(existingFileName, "Contents of pre-existing file")
+		documentProvider.save(existingFileName, "New contents of pre-existing file")
 
 		// then
 		git.assertSingleCommit(numberOfCommitsBefore, MODIFY, existingFileName)
@@ -87,11 +87,11 @@ class DocumentProviderTest extends AbstractGitTest {
 	@Test
 	def void savePushesChanges() {
 		// given
-		val existingFileName = preExistingFileInRepo
+		val existingFileName = createAndPushFileToRepo
 		val numberOfCommitsBefore = remoteGit.log.call.size
 
 		// when
-		documentProvider.save(existingFileName, "Contents of pre-existing file")
+		documentProvider.save(existingFileName, "New contents of pre-existing file")
 
 		// then
 		remoteGit.assertSingleCommit(numberOfCommitsBefore, MODIFY, existingFileName)
@@ -100,7 +100,7 @@ class DocumentProviderTest extends AbstractGitTest {
 	@Test
 	def void deleteCommitsChanges() {
 		// given
-		val existingFileName = preExistingFileInRepo
+		val existingFileName = createAndPushFileToRepo
 		val numberOfCommitsBefore = git.log.call.size
 
 		// when
@@ -113,7 +113,7 @@ class DocumentProviderTest extends AbstractGitTest {
 	@Test
 	def void deletePushesChanges() {
 		// given
-		val existingFileName = preExistingFileInRepo
+		val existingFileName = createAndPushFileToRepo
 		val numberOfCommitsBefore = remoteGit.log.call.size
 
 		// when
@@ -123,7 +123,7 @@ class DocumentProviderTest extends AbstractGitTest {
 		remoteGit.assertSingleCommit(numberOfCommitsBefore, DELETE, existingFileName)
 	}
 
-	private def preExistingFileInRepo() {
+	private def createAndPushFileToRepo() {
 		val filename = "preExistingFile.txt"
 		localGitRoot.newFile(filename).createNewFile
 		git.pull.call


### PR DESCRIPTION
As a first step, I added a couple of test cases against `DocumentProvider`, which document my assumptions regarding its expected behavior / interaction with Git.