### PR TITLE
Feature/git commit pull push avoid overrides

### DIFF
--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
@@ -57,6 +57,7 @@ class DocumentProvider {
 
 	def String load(String resourcePath) {
 		val file = getWorkspaceFile(resourcePath)
+		gitProvider.git.pull.call
 		return file.read
 	}
 

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
@@ -14,6 +14,7 @@ import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 import org.testeditor.web.dropwizard.auth.User
 
 import static java.nio.charset.StandardCharsets.*
+import static org.eclipse.jgit.lib.Constants.DOT_GIT
 
 /**
  * Similar to the default Xtext implementation but the calculated file URI needs to
@@ -114,7 +115,7 @@ class DocumentProvider {
 		val workspace = workspaceProvider.getWorkspace()
 		val file = new File(workspace, resourcePath)
 		verifyFileIsWithinWorkspace(workspace, file)
-		pullAndPush
+		initGitIfRequired
 		return file
 	}
 
@@ -124,6 +125,12 @@ class DocumentProvider {
 		val validPath = filePath.startsWith(workspacePath)
 		if (!validPath) {
 			throw new MaliciousPathException(workspacePath, filePath, userProvider.get.name)
+		}
+	}
+
+	private def void initGitIfRequired() {
+		if (!new File(workspaceProvider.workspace, DOT_GIT).exists) {
+			pullAndPush
 		}
 	}
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
@@ -256,5 +256,23 @@ class DocumentProviderTest extends AbstractGitTest {
 		localGitRoot.root.assertFileExists(existingFileName)
 		actualFileContents.assertEquals(expectedFileContents)
 	}
+	
+	@Test
+	def void loadPullsChangesWhenAlreadyInitialized() {
+		// given
+		val existingFileName = createPreExistingFileInRemoteRepository("preExistingFile.txt", "The initial file contents.\n")
+		documentProvider.load(existingFileName)
+
+		val fileContentsAfterChange = "The file contents after a remote change.\n"
+		remoteGitFolder.root.write(existingFileName, fileContentsAfterChange)
+		remoteGit.addAndCommit(existingFileName, "changes by someone else.")
+		
+		// when
+		val actualFileContents = documentProvider.load(existingFileName)
+		
+		// then
+		localGitRoot.root.assertFileExists(existingFileName)
+		actualFileContents.assertEquals(fileContentsAfterChange)
+	}
 
 }


### PR DESCRIPTION
* Always pulls changes on `load()`.
* Checks if the local working copy needs initializing – only then a pull is performed _before_  changes are applied. Should avoid "silently" overriding remote changes and instead lead to an automatic merge, or a conflict.

However, I would actually vote for a complete overhaul of `DocumentProvider`.