### PR TITLE
move test execution classes into a separate package

### DIFF
--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceApplication.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceApplication.xtend
@@ -3,6 +3,7 @@ package org.testeditor.web.backend.persistence
 import io.dropwizard.setup.Environment
 import org.testeditor.web.backend.persistence.exception.PersistenceExceptionMapper
 import org.testeditor.web.backend.persistence.workspace.WorkspaceResource
+import org.testeditor.web.backend.testexecution.TestExecutorResource
 import org.testeditor.web.dropwizard.DropwizardApplication
 
 class PersistenceApplication extends DropwizardApplication<PersistenceConfiguration> {

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
@@ -1,4 +1,4 @@
-package org.testeditor.web.backend.persistence
+package org.testeditor.web.backend.testexecution
 
 import java.lang.ProcessBuilder.Redirect
 import java.time.LocalDateTime
@@ -13,7 +13,6 @@ class TestExecutorProvider {
 
 	public static val LOGFILE_ENV_KEY = 'TE_TESTRUN_LOGFILE' // key into env, holding the actual log file
 	public static val LOG_FOLDER = 'logs' // log files will be created here
-
 	static val JAVA_TEST_SOURCE_PREFIX = 'src/test/java'
 	static val TEST_CASE_FILE_SUFFIX = 'tcl'
 
@@ -48,7 +47,7 @@ class TestExecutorProvider {
 		}
 		return testCase.toTestClassName
 	}
-	
+
 	private def String toTestClassName(String fileName) {
 		return fileName.replaceAll('''«JAVA_TEST_SOURCE_PREFIX»/''', '').replaceAll('''.«TEST_CASE_FILE_SUFFIX»$''', '').replaceAll('/', '.')
 	}
@@ -56,7 +55,7 @@ class TestExecutorProvider {
 	private def String[] constructCommandLine(String testClass, String logFile) {
 		return #['/bin/sh', '-c', testClass.gradleTestCommandLine.andLogInto(logFile)]
 	}
-	
+
 	private def String andLogInto(String testExecution, String logFile) {
 		return '''mkdir -p «LOG_FOLDER» && «testExecution» 2>&1 | tee «logFile»'''
 	}
@@ -68,5 +67,5 @@ class TestExecutorProvider {
 	private def String gradleTestCommandLine(String testClass) {
 		return '''./gradlew test --tests «testClass» --rerun-tasks'''
 	}
-	
+
 }

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorResource.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorResource.xtend
@@ -1,5 +1,6 @@
-package org.testeditor.web.backend.persistence
+package org.testeditor.web.backend.testexecution
 
+import java.net.URI
 import javax.inject.Inject
 import javax.ws.rs.Consumes
 import javax.ws.rs.POST
@@ -9,7 +10,7 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.UriBuilder
 import org.slf4j.LoggerFactory
-import java.net.URI
+import org.testeditor.web.backend.persistence.DocumentResource
 
 @Path("/tests")
 @Consumes(MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN)

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorIntegrationTest.xtend
@@ -1,13 +1,14 @@
-package org.testeditor.web.backend.persistence
+package org.testeditor.web.backend.testexecution
 
 import javax.ws.rs.client.Invocation.Builder
 import javax.ws.rs.core.HttpHeaders
+import javax.ws.rs.core.MultivaluedMap
 import javax.ws.rs.core.Response.Status
 import org.eclipse.jgit.junit.JGitTestUtil
 import org.junit.Test
+import org.testeditor.web.backend.persistence.AbstractPersistenceIntegrationTest
 
 import static org.assertj.core.api.Assertions.*
-import javax.ws.rs.core.MultivaluedMap
 
 class TestExecutorIntegrationTest extends AbstractPersistenceIntegrationTest {
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorTest.xtend
@@ -1,4 +1,4 @@
-package org.testeditor.web.backend.persistence
+package org.testeditor.web.backend.testexecution
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.slf4j.LoggerFactory
+import org.testeditor.web.backend.persistence.AbstractPersistenceTest
 import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 
 import static org.assertj.core.api.Assertions.*
@@ -103,8 +104,7 @@ class TestExecutorTest extends AbstractPersistenceTest {
 		verifyZeroInteractions(logAppender)
 
 		processBuilder => [
-			assertThat(command).haveAtLeastOne(
-				stringMatching(expectedCommandMatchingRegEx, 'gradle command line with test class'))
+			assertThat(command).haveAtLeastOne(stringMatching(expectedCommandMatchingRegEx, 'gradle command line with test class'))
 
 			assertThat(environment).hasEntrySatisfying(TestExecutorProvider.LOGFILE_ENV_KEY,
 				stringMatching(expectedLogFileMatchingRegEx, 'log file named accordingly'))
@@ -112,7 +112,7 @@ class TestExecutorTest extends AbstractPersistenceTest {
 			assertThat(directory.absolutePath).isEqualTo(temporaryFolder.root.absolutePath)
 		]
 	}
-	
+
 	private def Condition<String> stringMatching(String regEx, String message) {
 		return new Condition<String>([matches(regEx)], message)
 	}


### PR DESCRIPTION
This is in anticipation of eventually spinning off test execution into its own service, entirely.
There are, however, dependencies remaining to both `DocumentResource` and `WorkspaceProvider`.