### PR TITLE
fix response to test status request.

### DIFF
--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorResource.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorResource.xtend
@@ -54,20 +54,20 @@ class TestExecutorResource {
 			waitForStatus(resourcePath, response)
 		} else {
 			val status = statusMapper.getStatus(resourcePath)
-			response.resume(Response.ok(status).build)
+			response.resume(Response.ok(status.name).build)
 		}
 	}
-	
+
 	private def void waitForStatus(String resourcePath, AsyncResponse response) {
 
 		response.setTimeout(LONG_POLLING_TIMEOUT_SECONDS, TimeUnit.SECONDS)
 		response.timeoutHandler = [
-			resume(Response.ok(TestStatus.RUNNING).build)
+			resume(Response.ok(TestStatus.RUNNING.name).build)
 		]
 
 		try {
 			val status = statusMapper.waitForStatus(resourcePath)
-			response.resume(Response.ok(status).build)
+			response.resume(Response.ok(status.name).build)
 		} catch (InterruptedException ex) {
 		} // timeout handler takes care of response
 	}

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorIntegrationTest.xtend
@@ -64,7 +64,7 @@ class TestExecutorIntegrationTest extends AbstractPersistenceIntegrationTest {
 		val actualTestStatus = createTestStatusRequest(testFile).get
 
 		// then
-		assertThat(actualTestStatus.readEntity(TestStatus)).isEqualTo(TestStatus.RUNNING)
+		assertThat(actualTestStatus.readEntity(String)).isEqualTo('RUNNING')
 
 	}
 
@@ -88,7 +88,7 @@ class TestExecutorIntegrationTest extends AbstractPersistenceIntegrationTest {
 		val actualTestStatus = createAsyncTestStatusRequest(testFile).get
 
 		// then
-		assertThat(actualTestStatus.readEntity(TestStatus)).isEqualTo(TestStatus.SUCCESS)
+		assertThat(actualTestStatus.readEntity(String)).isEqualTo('SUCCESS')
 
 	}
 
@@ -112,7 +112,7 @@ class TestExecutorIntegrationTest extends AbstractPersistenceIntegrationTest {
 		val actualTestStatus = createAsyncTestStatusRequest(testFile).get
 
 		// then
-		assertThat(actualTestStatus.readEntity(TestStatus)).isEqualTo(TestStatus.FAILED)
+		assertThat(actualTestStatus.readEntity(String)).isEqualTo('FAILED')
 
 	}
 
@@ -133,21 +133,21 @@ class TestExecutorIntegrationTest extends AbstractPersistenceIntegrationTest {
 		assertThat(executionResponse.status).isEqualTo(Status.CREATED.statusCode)
 
 		val longPollingRequest = createAsyncTestStatusRequest(testFile).async
-		val statusList = <TestStatus>newLinkedList(TestStatus.RUNNING)
+		val statusList = <String>newLinkedList('RUNNING')
 
 		// when
-		for (var i = 0; i < 4 && statusList.head.equals(TestStatus.RUNNING); i++) {
+		for (var i = 0; i < 4 && statusList.head.equals('RUNNING'); i++) {
 				val future = longPollingRequest.get
 				val response = future.get(120, TimeUnit.SECONDS)
 				assertThat(response.status).isEqualTo(200)
-				statusList.offerFirst(response.readEntity(TestStatus))
+				statusList.offerFirst(response.readEntity(String))
 				response.close
 		}
 
 		// then
 		assertThat(statusList.size).isGreaterThan(3)
-		assertThat(statusList.tail).allMatch[TestStatus.RUNNING.equals(it)]
-		assertThat(statusList.head).isEqualTo(TestStatus.SUCCESS)
+		assertThat(statusList.tail).allMatch['RUNNING'.equals(it)]
+		assertThat(statusList.head).isEqualTo('SUCCESS')
 
 	}
 


### PR DESCRIPTION
A simple string should now be returned, on of "RUNNING", "SUCCESS", "FAILED", or "IDLE" – without the quote marks.
The corresponding enum was previously serialized directly, leading to a response containing the string including the enclosing quote marks.