### PR TITLE
add flag to redirect stderr to stdout during test execution

### DIFF
--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
@@ -26,6 +26,7 @@ class TestExecutorProvider {
 			command(constructCommandLine(testClass, logFile))
 			directory(workingDir)
 			environment.put(LOGFILE_ENV_KEY, logFile)
+			redirectErrorStream(true)
 		]
 
 		return processBuilder


### PR DESCRIPTION
… without this, anything the process sends to standard error will **not** appear in the log. It will also not be written back to the console, because we "internalized" all process output handling into our Java application, which does not explicitly do anything with the process object's error stream.