### PR TITLE
put test file into default search path

### DIFF
--- a/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/XtextIndexIntegrationTest.xtend
+++ b/org.testeditor.web.backend.xtext/src/test/java/org/testeditor/web/backend/xtext/index/XtextIndexIntegrationTest.xtend
@@ -10,7 +10,7 @@ class XtextIndexIntegrationTest extends AbstractTestEditorIntegrationTest {
 
 	override protected initializeRemoteRepository(Git git, File parent) {
 		super.initializeRemoteRepository(git, parent)
-		writeToRemote('dummy.aml', '''
+		writeToRemote('src/test/java/dummy.aml', '''
 			component type DummyType
 			component DummyComponent is DummyType
 		''')


### PR DESCRIPTION
files outside of the configured search path are filtered out and won't be indexed.