### PR TITLE
Feature/collision detection

### DIFF
--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/ConflictingModificationsException.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/ConflictingModificationsException.xtend
@@ -1,11 +1,11 @@
 package org.testeditor.web.backend.persistence
 
-import java.lang.Exception
+import org.testeditor.web.backend.persistence.exception.PersistenceException
 
-class ConflictingModificationsException extends Exception {
-	
+class ConflictingModificationsException extends PersistenceException {
+
 	new(String message) {
 		super(message)
 	}
-	
+
 }

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/ConflictingModificationsException.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/ConflictingModificationsException.xtend
@@ -1,0 +1,11 @@
+package org.testeditor.web.backend.persistence
+
+import java.lang.Exception
+
+class ConflictingModificationsException extends Exception {
+	
+	new(String message) {
+		super(message)
+	}
+	
+}

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
@@ -58,20 +58,6 @@ class DocumentProvider {
 		return folder.mkdirs
 	}
 
-	/**
-	 * @return true when the file has been created
-	 */
-	def boolean createOrUpdate(String resourcePath, String content) {
-		val file = getWorkspaceFile(resourcePath)
-		var created = false
-		if (!file.exists) {
-			created = resourcePath.create(content)
-		} else {
-			resourcePath.save(content)
-		}
-		return created
-	}
-
 	def String load(String resourcePath) {
 		val file = getWorkspaceFile(resourcePath)
 		pull

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
@@ -86,10 +86,15 @@ class DocumentProvider {
 
 	def String load(String resourcePath) {
 		val file = getWorkspaceFile(resourcePath)
-		if (!regardAsBinary(resourcePath)) {
-			return file.read
+
+		if (file.exists) {
+			if (!regardAsBinary(resourcePath)) {
+				return file.read
+			} else {
+				throw new IllegalStateException('''File "«file.name»" appears to be binary and cannot be loaded as text.''')
+			}
 		} else {
-			throw new IllegalStateException('''File "«file.name»" appears to be binary and cannot be loaded as text.''')
+			throw new FileNotFoundException('''The file '«resourcePath»' does not exist. It may have been concurrently deleted.''')
 		}
 	}
 

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentResource.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentResource.xtend
@@ -45,13 +45,9 @@ class DocumentResource {
 	}
 
 	@PUT
-	def Response createOrUpdate(@PathParam("resourcePath") String resourcePath, String content, @Context HttpHeaders headers) {
-		val created = documentProvider.createOrUpdate(resourcePath, content)
-		if (created) {
-			return status(CREATED).build
-		} else {
-			return status(NO_CONTENT).build
-		}
+	def Response update(@PathParam("resourcePath") String resourcePath, String content, @Context HttpHeaders headers) {
+		documentProvider.save(resourcePath, content)
+		return status(NO_CONTENT).build
 	}
 
 	@GET

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentResource.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentResource.xtend
@@ -53,17 +53,9 @@ class DocumentResource {
 	@GET
 	def Response load(@PathParam("resourcePath") String resourcePath, @Context HttpHeaders headers) {
 		try {
-			return resourcePath.loadIntoResponse.build
+			return status(OK).entity(documentProvider.load(resourcePath)).type(documentProvider.getType(resourcePath)).build
 		} catch (FileNotFoundException e) {
 			return status(NOT_FOUND).build
-		}
-	}
-
-	private def loadIntoResponse(String resourcePath) {
-		if (documentProvider.regardAsBinary(resourcePath)) {
-			status(OK).entity(documentProvider.loadBinary(resourcePath)).type(documentProvider.getType(resourcePath))
-		} else {
-			status(OK).entity(documentProvider.load(resourcePath)).type(MediaType.TEXT_PLAIN)
 		}
 	}
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
@@ -1,10 +1,12 @@
 package org.testeditor.web.backend.persistence
 
 import java.io.File
-import java.io.FileInputStream
-import java.util.Arrays
+import java.io.FileNotFoundException
+import java.nio.charset.StandardCharsets
 import javax.inject.Inject
+import org.apache.commons.io.IOUtils
 import org.assertj.core.api.SoftAssertions
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
@@ -12,10 +14,6 @@ import org.testeditor.web.backend.persistence.git.AbstractGitTest
 
 import static org.assertj.core.api.Assertions.assertThat
 import static org.eclipse.jgit.diff.DiffEntry.ChangeType.*
-
-import static extension com.google.common.io.ByteStreams.*
-import org.junit.Before
-import java.io.FileNotFoundException
 
 class DocumentProviderTest extends AbstractGitTest {
 
@@ -171,7 +169,7 @@ class DocumentProviderTest extends AbstractGitTest {
 
 		// then
 		localGitRoot.root.assertFileExists(existingFileName)
-		actualFileContents.assertEquals(expectedFileContents)
+		IOUtils.toString(actualFileContents, StandardCharsets.UTF_8).assertEquals(expectedFileContents)
 	}
 
 	@Test
@@ -209,56 +207,6 @@ class DocumentProviderTest extends AbstractGitTest {
 
 		// then
 		gitProvider.git.lastCommit.fullMessage.assertEquals('''delete file: «existingFileName»'''.toString)
-	}
-
-	@Test
-	def void recognizesBinaryFile() {
-		// given
-		val existingImageFile = createPreExistingBinaryFileInRemoteRepository("image.png")
-
-		// when
-		val boolean actual = documentProvider.regardAsBinary(existingImageFile)
-
-		// then
-		assertTrue(actual)
-	}
-
-	@Test
-	def void recognizesTextFile() {
-		// given
-		val existingFileName = createPreExistingFileInRemoteRepository("file.tcl", "Plain-text content")
-
-		// when
-		val actual = documentProvider.regardAsBinary(existingFileName)
-
-		// then
-		assertFalse(actual)
-	}
-
-	@Test
-	def void loadBinaryReturnsContentAsStream() {
-		// given
-		val expectedContents = new FileInputStream(BINARY_FILE).toByteArray
-		val existingImageFile = createPreExistingBinaryFileInRemoteRepository("image.png")
-
-		// when
-		val actualContents = documentProvider.loadBinary(existingImageFile)
-
-		// then
-		assertTrue(Arrays.equals(actualContents.toByteArray, expectedContents))
-	}
-
-	@Test
-	def void loadOnBinaryFileRaisesException() {
-		// given
-		val existingImageFile = createPreExistingBinaryFileInRemoteRepository("image.png")
-
-		// then (!)
-		exception.expect(IllegalStateException)
-		exception.expectMessage('''File "«existingImageFile»" appears to be binary and cannot be loaded as text.''')
-
-		// when
-		documentProvider.load(existingImageFile)
 	}
 
 	@Test

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
@@ -101,34 +101,6 @@ class DocumentProviderTest extends AbstractGitTest {
 	}
 
 	@Test
-	def void createOrUpdateNonExistingFileAddsAndCommits() {
-		// given
-		val nonExistingFile = "aFileThatHasNotYetBeenCreated.txt"
-		val numberOfCommitsBefore = remoteGit.log.call.size
-
-		// when
-		documentProvider.createOrUpdate(nonExistingFile, "Contents of new file")
-
-		// then
-		gitProvider.git.assertSingleCommit(numberOfCommitsBefore, ADD, nonExistingFile)
-	}
-
-	@Test
-	def void createOrUpdatePreExistingFileCommitsModifications() {
-		// given
-		val preExistingFile = createPreExistingFileInRemoteRepository
-		val localGit = gitProvider.git
-		localGit.pull.call
-		val numberOfCommitsBefore = localGit.log.call.size
-
-		// when
-		documentProvider.createOrUpdate(preExistingFile, "New contents of pre-existing file")
-
-		// then
-		localGit.assertSingleCommit(numberOfCommitsBefore, MODIFY, preExistingFile)
-	}
-
-	@Test
 	def void saveCommitsChanges() {
 		// given
 		val existingFileName = createPreExistingFileInRemoteRepository
@@ -383,6 +355,7 @@ class DocumentProviderTest extends AbstractGitTest {
 			]
 		}
 	}
+	
 	
 	@Test
 	def void createNewEmptyFileAlreadyExistingOnRemoteRaisesException() {		

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentResourceIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentResourceIntegrationTest.xtend
@@ -122,22 +122,10 @@ class DocumentResourceIntegrationTest extends AbstractPersistenceIntegrationTest
 	}
 
 	@Test
-	def void canCreateDocumentUsingPut() {
-		// given
-		val request = createDocumentRequest(resourcePath).buildPut(stringEntity(simpleTsl))
-
-		// when
-		val response = request.submit.get
-
-		// then
-		response.status.assertEquals(CREATED.statusCode)
-		read(resourcePath).assertEquals(simpleTsl)
-	}
-
-	@Test
 	def void canUpdateDocumentUsingPut() {
 		// given
 		write(resourcePath, simpleTsl)
+		createRequest('workspace/list-files').buildGet.submit.get
 		val updateText = "updated"
 		val request = createDocumentRequest(resourcePath).buildPut(stringEntity(updateText))
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentResourceIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentResourceIntegrationTest.xtend
@@ -10,6 +10,7 @@ import javax.ws.rs.client.Invocation.Builder
 import javax.ws.rs.core.MediaType
 import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.api.Git
+import org.junit.Before
 import org.junit.Test
 
 import static javax.ws.rs.core.Response.Status.*
@@ -27,6 +28,11 @@ class DocumentResourceIntegrationTest extends AbstractPersistenceIntegrationTest
 	'''
 	val binaryResourcePath = "some/parent/folder/image.png"
 	val binaryContentsFile = new File("src/test/resources/sample-binary-file.png")
+	
+	@Before
+	def void initGitInLocalWorkspace() {
+		createRequest('workspace/list-files').buildGet.submit.get
+	}
 
 	@Test
 	def void canCreateDocumentUsingPost() {

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorIntegrationTest.xtend
@@ -188,7 +188,7 @@ class TestExecutorIntegrationTest extends AbstractPersistenceIntegrationTest {
 		workspaceRoot.newFile('''«userId»/gradlew''') => [
 			executable = true
 			JGitTestUtil.write(it, '''
-				#!/bin/sh
+				#!/bin/bash
 				if [ "$3" = "runningTest" ]; then
 				  sleep 10; exit 0
 				elif [ "$3" = "successfulTest" ]; then


### PR DESCRIPTION
DocumentProvider now detects changes.

The contract of the class changed insofar as it is not safe anymore to call into any of its methods without ensuring that the underlying GitProvider was initialized, first. The class itself cannot do that anymore, as initializing the local Git repo before performing the requested file changes would potentially leave conflict situations undetected. E.g. if 'save' is invoked, and a Git clone is performed first, concurrent changes that may have occurred remotely will subsequently be overridden. If the save is performed on an uninitialized directory, subsequent attempts to clone / init Git will fail, because the directory would not be empty, anymore.

Invoking WorkspaceProvider's 'list-files' should ensure that subsequent calls to DocumentProvider methods work as intended. Normal usage of the Test-Editor conforms to this protocol, as the workspace is loaded right after login, before any other file actions can take place.

ToDo: the corresponding DocumentResource needs to be adapted (or at least the exception mapper), so that conflict exceptions are reported back via the REST endpoints.