### PR TITLE
Feature/collision detection rest endpoint

### DIFF
--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/ConflictingModificationsException.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/ConflictingModificationsException.xtend
@@ -1,11 +1,16 @@
 package org.testeditor.web.backend.persistence
 
+import org.eclipse.xtend.lib.annotations.Accessors
 import org.testeditor.web.backend.persistence.exception.PersistenceException
 
 class ConflictingModificationsException extends PersistenceException {
 
-	new(String message) {
+	@Accessors(PUBLIC_GETTER)
+	val String backupFilePath
+
+	new(String message, String backupFilePath) {
 		super(message)
+		this.backupFilePath = backupFilePath
 	}
 
 }

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/ConflictingModificationsException.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/ConflictingModificationsException.xtend
@@ -7,6 +7,10 @@ class ConflictingModificationsException extends PersistenceException {
 
 	@Accessors(PUBLIC_GETTER)
 	val String backupFilePath
+	
+	new(String message) {
+		this(message, null)
+	}
 
 	new(String message, String backupFilePath) {
 		super(message)

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
@@ -167,15 +167,16 @@ class DocumentProvider {
 	private def void resetToRemoteAndCreateBackup(StageState mergeConflictState, String resourcePath, String content) {
 		resetToRemoteState
 		var exceptionMessage = mergeConflictState.getConflictMessage(resourcePath)
+		var String backupFilePath = null
 		if (!content.isNullOrEmpty) {
 			try {
-				val backupFileName = createLocalBackup(resourcePath, content)
-				exceptionMessage = exceptionMessage.appendBackupNote(backupFileName)
+				backupFilePath = createLocalBackup(resourcePath, content)
+				exceptionMessage = exceptionMessage.appendBackupNote(backupFilePath)
 			} catch (IllegalStateException exception) {
 				exceptionMessage += ' ' + exception.message
 			}
 		}
-		throw new ConflictingModificationsException(exceptionMessage)
+		throw new ConflictingModificationsException(exceptionMessage, backupFilePath)
 	}
 
 	private def createLocalBackup(String resourcePath, String content) {

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/DocumentProvider.xtend
@@ -183,16 +183,16 @@ class DocumentProvider {
 		val workspace = workspaceProvider.workspace
 		var fileSuffix = BACKUP_FILE_SUFFIX
 		var backupFile = new File(workspace, resourcePath + fileSuffix)
-		if (backupFile.exists) {
+		if (!backupFile.create) {
 			val numberSuffix = (0..MAX_BACKUP_FILE_NUMBER_SUFFIX).findFirst[ i |
-				!new File(workspace, '''«resourcePath»«BACKUP_FILE_SUFFIX»-«i»''').exists
+				new File(workspace, '''«resourcePath»«BACKUP_FILE_SUFFIX»-«i»''').create
 			]
 			if (numberSuffix !== null) {
 				fileSuffix = '''«BACKUP_FILE_SUFFIX»-«numberSuffix»'''
 				backupFile = new File(workspace, '''«resourcePath»«fileSuffix»''')
 			} else {
 				throw new IllegalStateException('''Could not create a backup file for '«resourcePath»': backup file limit reached.''')
-			}			
+			}
 		}
 		Files.asCharSink(backupFile, UTF_8).write(content)
 		return resourcePath + fileSuffix

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/exception/PersistenceExceptionMapper.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/exception/PersistenceExceptionMapper.xtend
@@ -1,20 +1,34 @@
 package org.testeditor.web.backend.persistence.exception
 
 import io.dropwizard.jersey.errors.LoggingExceptionMapper
+import java.net.URI
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.Provider
+import org.testeditor.web.backend.persistence.ConflictingModificationsException
 
 @Provider
 class PersistenceExceptionMapper extends LoggingExceptionMapper<PersistenceException> {
 
-	def dispatch toResponse(MaliciousPathException e) {
+	def dispatch Response toResponse(MaliciousPathException e) {
 		val logId = logException(e)
 		val message = String.format("You are not allowed to access this resource. Your attempt has been logged (ID %016x).", logId);
 		return Response.status(Response.Status.FORBIDDEN).entity(message).build
 	}
 
-	def dispatch toResponse(PersistenceException e) {
-		Response.serverError.build
+	def dispatch Response toResponse(ConflictingModificationsException conflictException) {
+		logException(conflictException)
+
+		val response = Response.status(Response.Status.CONFLICT).entity(conflictException.message)
+
+		return if (conflictException.backupFilePath !== null) {
+			response.contentLocation(URI.create(conflictException.backupFilePath)).build
+		} else {
+			response.build
+		}
+	}
+
+	def dispatch Response toResponse(PersistenceException e) {
+		return Response.serverError.build
 	}
 
 }

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentProviderTest.xtend
@@ -237,7 +237,8 @@ class DocumentProviderTest extends AbstractGitTest {
 				assertThat(exception.message).isEqualTo(
 					'''The file '«existingFileName»' could not be saved due to concurrent modifications. ''' +
 					'''Local changes were instead backed up to '«backupFileName»'.''')
-				assertThat(backupFile).exists.hasContent(localChange)
+				assertThat(backupFile).exists
+				assertThat(backupFile).hasContent(localChange)
 				assertThat(localGit.status.call.untracked).contains(backupFileName)
 				assertThat(existingFile).exists.hasContent(remoteChange)
 				assertAll
@@ -288,7 +289,7 @@ class DocumentProviderTest extends AbstractGitTest {
 	@Test
 	def void saveRemotelyDeletedFileCreatesBackupFileAndRaisesException() {
 		// given
-		val existingFileName = createPreExistingFileInRemoteRepository
+		val existingFileName = createPreExistingFileInRemoteRepository('tmp/test.txt')
 		val localChange = 'Contents of file after local change'
 		val localGit = gitProvider.git
 		localGit.pull.call
@@ -310,7 +311,8 @@ class DocumentProviderTest extends AbstractGitTest {
 				assertThat(exception.message).isEqualTo(
 					'''The file '«existingFileName»' could not be saved as it was concurrently being deleted. ''' +
 					'''Local changes were instead backed up to '«backupFileName»'.''')
-				assertThat(backupFile).exists.hasContent(localChange)
+				assertThat(backupFile).exists
+				assertThat(backupFile).hasContent(localChange)
 				assertThat(localGit.status.call.untracked).contains(backupFileName)
 				assertAll
 			]

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentResourceIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentResourceIntegrationTest.xtend
@@ -254,7 +254,7 @@ class DocumentResourceIntegrationTest extends AbstractPersistenceIntegrationTest
 		response.status.assertEquals(CONFLICT.statusCode)
 		readRemote(resourcePath).assertEquals(simpleTsl)
 		readLocal(resourcePath).assertEquals(simpleTsl)
-		new File(workspaceRoot.root, resourcePath + DocumentProvider.backupExtension).exists.assertFalse
+		new File(workspaceRoot.root, resourcePath + '.local-backup').exists.assertFalse
 	}
 	
 	@Test

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentResourceIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/DocumentResourceIntegrationTest.xtend
@@ -44,7 +44,7 @@ class DocumentResourceIntegrationTest extends AbstractPersistenceIntegrationTest
 
 		// then
 		response.status.assertEquals(CREATED.statusCode)
-		read(resourcePath).assertEquals(simpleTsl)
+		readRemote(resourcePath).assertEquals(simpleTsl)
 	}
 
 	@Test
@@ -72,7 +72,7 @@ class DocumentResourceIntegrationTest extends AbstractPersistenceIntegrationTest
 
 		// then
 		response.status.assertEquals(BAD_REQUEST.statusCode)
-		read(resourcePath).assertEquals(simpleTsl)
+		readRemote(resourcePath).assertEquals(simpleTsl)
 	}
 
 	@Test
@@ -134,7 +134,7 @@ class DocumentResourceIntegrationTest extends AbstractPersistenceIntegrationTest
 
 		// then
 		response.status.assertEquals(NO_CONTENT.statusCode)
-		read(resourcePath).assertEquals(updateText)
+		readRemote(resourcePath).assertEquals(updateText)
 	}
 
 	@Test
@@ -240,6 +240,59 @@ class DocumentResourceIntegrationTest extends AbstractPersistenceIntegrationTest
 		// then
 		response.status.assertEquals(NOT_FOUND.statusCode)
 	}
+	
+	@Test
+	def void conflictIsReturnedWhenUpdatingWithRemoteChanges() {
+		// given
+		write(resourcePath, simpleTsl)
+		createRequest('workspace/list-files').buildGet.submit.get
+		write(resourcePath, simpleTsl + '\nRemote Change')
+		
+		val updateText = simpleTsl + '\nLocal Change'
+		val request = createDocumentRequest(resourcePath).buildPut(stringEntity(updateText))
+
+		// when
+		val response = request.submit.get
+
+		// then
+		val backupPath = resourcePath + '.local-backup'
+		response.status.assertEquals(CONFLICT.statusCode)
+		response.readEntity(String).assertEquals(
+			'''The file '«resourcePath»' could not be saved due to concurrent modifications. ''' +
+			'''Local changes were instead backed up to '«backupPath»'.''')
+		response.headers.get('content-location').head.assertEquals(backupPath)
+		readLocal(resourcePath).assertEquals(simpleTsl + '\nRemote Change')
+		readLocal(backupPath).assertEquals(simpleTsl + '\nLocal Change')
+	}	
+	
+		@Test
+	def void conflictIsReturnedWhenUpdatingWithRemoteDeleted() {
+		// given
+		write(resourcePath, simpleTsl)
+		createRequest('workspace/list-files').buildGet.submit.get
+		
+		val remoteGit = Git.open(remoteGitFolder.root)
+		remoteGit.rm.addFilepattern(resourcePath).call
+		remoteGit.commit.setMessage('file deleted').call
+		
+		
+		val updateText = simpleTsl + '\nLocal Change'
+		val request = createDocumentRequest(resourcePath).buildPut(stringEntity(updateText))
+
+		// when
+		val response = request.submit.get
+
+		// then
+		val backupPath = resourcePath + '.local-backup'
+		response.status.assertEquals(CONFLICT.statusCode)
+		response.readEntity(String).assertEquals(
+			'''The file '«resourcePath»' could not be saved as it was concurrently being deleted.''' + 
+			''' Local changes were instead backed up to '«backupPath»'.'''.toString)
+		response.headers.get('content-location').head.assertEquals(backupPath)
+		new File(workspaceRoot.root, resourcePath).exists.assertFalse
+		readLocal(backupPath).assertEquals(simpleTsl + '\nLocal Change')
+	}	
+	
 
 	private def Entity<String> stringEntity(CharSequence charSequence) {
 		return Entity.entity(charSequence.toString, MediaType.TEXT_PLAIN)
@@ -259,8 +312,14 @@ class DocumentResourceIntegrationTest extends AbstractPersistenceIntegrationTest
 		return file
 	}
 
-	private def String read(String resourcePath) {
+	private def String readRemote(String resourcePath) {
 		val file = getRemoteFile(resourcePath)
+		file.exists.assertTrue('''File with path='«resourcePath»' does not exist.''')
+		return FileUtils.readFileToString(file, StandardCharsets.UTF_8)
+	}
+	
+	private def String readLocal(String resourcePath) {
+		val file = getLocalFile(resourcePath)
 		file.exists.assertTrue('''File with path='«resourcePath»' does not exist.''')
 		return FileUtils.readFileToString(file, StandardCharsets.UTF_8)
 	}


### PR DESCRIPTION
Check out #61 first.

Adapts DocumentResource / PersistenceExceptionMapper to handle conflict exceptions thrown by DocumentProvider (as of #61). Adds integration tests for conflict scenarios.