### PR TITLE
allow browsers to expose 'Content-Location' header

### DIFF
--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceApplication.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceApplication.xtend
@@ -2,13 +2,18 @@ package org.testeditor.web.backend.persistence
 
 import com.google.inject.Module
 import io.dropwizard.setup.Environment
+import java.util.EnumSet
 import java.util.List
 import java.util.concurrent.Executor
 import java.util.concurrent.ForkJoinPool
+import javax.servlet.DispatcherType
+import org.eclipse.jetty.servlets.CrossOriginFilter
 import org.testeditor.web.backend.persistence.exception.PersistenceExceptionMapper
 import org.testeditor.web.backend.persistence.workspace.WorkspaceResource
 import org.testeditor.web.backend.testexecution.TestExecutorResource
 import org.testeditor.web.dropwizard.DropwizardApplication
+
+import static org.eclipse.jetty.servlets.CrossOriginFilter.*
 
 class PersistenceApplication extends DropwizardApplication<PersistenceConfiguration> {
 
@@ -30,6 +35,25 @@ class PersistenceApplication extends DropwizardApplication<PersistenceConfigurat
 			register(WorkspaceResource)
 			register(TestExecutorResource)
 			register(PersistenceExceptionMapper)
+		]
+	}
+
+	override def void configureCorsFilter(PersistenceConfiguration configuration, Environment environment) {
+		environment.servlets.addFilter("CORS", CrossOriginFilter) => [
+			// Configure CORS parameters
+			setInitParameter(ALLOWED_ORIGINS_PARAM, "*")
+			setInitParameter(ALLOWED_HEADERS_PARAM, "*")
+			setInitParameter(ALLOWED_METHODS_PARAM, "OPTIONS,GET,PUT,POST,DELETE,HEAD")
+			setInitParameter(ALLOW_CREDENTIALS_PARAM, "true")
+			setInitParameter(EXPOSED_HEADERS_PARAM, "Content-Location")
+
+			// Add URL mapping
+			addMappingForUrlPatterns(EnumSet.allOf(DispatcherType), true, "/*")
+
+			// from https://stackoverflow.com/questions/25775364/enabling-cors-in-dropwizard-not-working
+			// DO NOT pass a preflight request to down-stream auth filters
+			// unauthenticated preflight requests should be permitted by spec
+			setInitParameter(CrossOriginFilter.CHAIN_PREFLIGHT_PARAM, "false");
 		]
 	}
 


### PR DESCRIPTION
CORS settings in our Dropwizard stack do not allow browsers to expose most headers (including standard ones, like 'Content-Location') to client applications; see e.g. [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers).

I had to basically copy over a method from the base class, because the API is too restrictive. It seems I cannot access the CrossOriginFilter after its been added. The method would be more useful (extensible) if it returned the filter object for further configuration.

I will prepare a coresponding refactoring in the base class, but that's in [xtext-dropwizard](https://github.com/test-editor/xtext-dropwizard), so in the meantime, I suggest we use this…