### PR TITLE
ability to set custom trust store on first use

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -51,7 +51,7 @@ then
 				fi
 				if [ ! -z "$TRUST_STORE" ]
 				then
-					echo "export JAVAX_NET_SSL_TRUSTSTORE=$TRUST_STORE" > .javaTrustStore
+					echo "export _JAVA_OPTIONS=\"-Djavax.net.ssl.trustStore=$TRUST_STORE \$_JAVA_OPTIONS\"" > .javaTrustStore
 				fi
 				break
 				;;

--- a/.envrc
+++ b/.envrc
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+trap "touch .javaTrustStore; exit" SIGINT SIGTERM
+
 FEDORA_TRUST_STORE="/etc/pki/ca-trust/extracted/java/cacerts"
-DEFAULT_TRUST_STORE=$(readlink -e $(dirname $(readlink -e $(which keytool)))/../lib/security/cacerts)
+{ DEFAULT_TRUST_STORE=$(readlink -e $(dirname $(readlink -e $(which keytool)))/../lib/security/cacerts) ; } >/dev/null 2>&1 || :
 
 
 function enterTrustStorePath() {
 	echo "Enter the path to the Java trust store to be used"
-	echo
 	read TRUST_STORE
 }
 
@@ -48,15 +49,18 @@ then
 				else
 					enterTrustStorePath
 				fi
-				echo "export JAVAX_NET_SSL_TRUSTSTORE=$TRUST_STORE" > .javaTrustStore
+				if [ ! -z "$TRUST_STORE" ]
+				then
+					echo "export JAVAX_NET_SSL_TRUSTSTORE=$TRUST_STORE" > .javaTrustStore
+				fi
 				break
 				;;
 			No)
-				touch .javaTrustStore
 				break
 				;;
 		esac
 	done
+	touch .javaTrustStore
 	echo "Saved to file '.javaTrustStore'. Please DO NOT put this file under version control."
 	echo "Should you change your mind, simply deleta that file, and say 'direnv reload' for a do-over."
 fi

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,65 @@
+#!/bin/bash
+
+FEDORA_TRUST_STORE="/etc/pki/ca-trust/extracted/java/cacerts"
+DEFAULT_TRUST_STORE=$(readlink -e $(dirname $(readlink -e $(which keytool)))/../lib/security/cacerts)
+
+
+function enterTrustStorePath() {
+	echo "Enter the path to the Java trust store to be used"
+	echo
+	read TRUST_STORE
+}
+
+if [ ! -e .javaTrustStore ]
+then
+	echo "Do you want to use a trust store of a local Java installation?"
+	echo "(If you are behind a corporate firewall, chances are you want to say 'yes')"
+	select USE_LOCAL in "Yes" "No"
+	do
+		case $USE_LOCAL in
+			Yes)
+				if [ -e "$FEDORA_TRUST_STORE" ]
+				then
+					TRUST_STORE="$FEDORA_TRUST_STORE"
+				else
+					if [ -e "$DEFAULT_TRUST_STORE" ]
+					then
+						TRUST_STORE="$DEFAULT_TRUST_STORE"
+					else
+						TRUST_STORE=""
+					fi
+				fi
+				if [ ! -z "$TRUST_STORE" ]
+				then
+					echo "I tried to guess your Java trust store location. Does this look right?"
+					echo "  $TRUST_STORE"
+					select USE_DEFAULT in "Yes" "No"
+					do
+						case $USE_DEFAULT in
+							No)
+								enterTrustStorePath
+								break
+								;;
+							Yes)
+								break
+								;;
+						esac
+					done
+				else
+					enterTrustStorePath
+				fi
+				echo "export JAVAX_NET_SSL_TRUSTSTORE=$TRUST_STORE" > .javaTrustStore
+				break
+				;;
+			No)
+				touch .javaTrustStore
+				break
+				;;
+		esac
+	done
+	echo "Saved to file '.javaTrustStore'. Please DO NOT put this file under version control."
+	echo "Should you change your mind, simply deleta that file, and say 'direnv reload' for a do-over."
+fi
+
+source .javaTrustStore
 use_nix

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ xtend-gen/
 init.gradle
 config.local.yml
 /org.testeditor.web.backend.xtext/repo/
+.javaTrustStore
 
 ### test executions ###
 xvfb.error.log


### PR DESCRIPTION
Prompt the user to choose whether to use the trust store of a locally installed JDK, instead of the default one (installed within the nix shell).

In an existing working copy, you should be able to simply switch to this branch to see it in action, immediately.
To try it out from a fresh checkout, do, for example:
```
cd /tmp
git clone --single-branch --branch feature/custom-trust-store https://github.com/test-editor/test-editor-backend.git
cd test-editor-backend
direnv allow
```
... and to see if Gradle works:
```
mkdir fresh-cache
./gradlew clean -g fresh-cache
```