### PR TITLE
remove tight coupling to test execution

### DIFF
--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceConfiguration.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceConfiguration.xtend
@@ -4,9 +4,10 @@ import javax.inject.Singleton
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.hibernate.validator.constraints.NotEmpty
 import org.testeditor.web.dropwizard.DropwizardApplicationConfiguration
+import org.testeditor.web.backend.testexecution.TestExecutionConfiguration
 
 @Singleton
-class PersistenceConfiguration extends DropwizardApplicationConfiguration {
+class PersistenceConfiguration extends DropwizardApplicationConfiguration implements TestExecutionConfiguration {
 	enum RepositoryConnectionMode { pullPush, pullOnly }
 
 	@NotEmpty

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceModule.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceModule.xtend
@@ -5,8 +5,6 @@ import com.google.inject.Provides
 import java.io.File
 import java.util.concurrent.Executor
 import java.util.concurrent.ForkJoinPool
-import org.testeditor.web.backend.persistence.util.HierarchicalLineSkipper
-import org.testeditor.web.backend.persistence.util.RecursiveHierarchicalLineSkipper
 import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 import org.testeditor.web.backend.testexecution.TestExecutionConfiguration
 import org.testeditor.web.backend.testexecution.loglines.Log4JDefaultFilter
@@ -15,6 +13,8 @@ import org.testeditor.web.backend.testexecution.loglines.LogFinder
 import org.testeditor.web.backend.testexecution.loglines.ScanningLogFinder
 import org.testeditor.web.backend.testexecution.screenshots.ScreenshotFinder
 import org.testeditor.web.backend.testexecution.screenshots.SubStepAggregatingScreenshotFinder
+import org.testeditor.web.backend.testexecution.util.HierarchicalLineSkipper
+import org.testeditor.web.backend.testexecution.util.RecursiveHierarchicalLineSkipper
 
 import static com.google.inject.name.Names.named
 

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceModule.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/PersistenceModule.xtend
@@ -2,16 +2,21 @@ package org.testeditor.web.backend.persistence
 
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
+import java.io.File
 import java.util.concurrent.Executor
 import java.util.concurrent.ForkJoinPool
 import org.testeditor.web.backend.persistence.util.HierarchicalLineSkipper
 import org.testeditor.web.backend.persistence.util.RecursiveHierarchicalLineSkipper
+import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
+import org.testeditor.web.backend.testexecution.TestExecutionConfiguration
 import org.testeditor.web.backend.testexecution.loglines.Log4JDefaultFilter
 import org.testeditor.web.backend.testexecution.loglines.LogFilter
 import org.testeditor.web.backend.testexecution.loglines.LogFinder
 import org.testeditor.web.backend.testexecution.loglines.ScanningLogFinder
 import org.testeditor.web.backend.testexecution.screenshots.ScreenshotFinder
 import org.testeditor.web.backend.testexecution.screenshots.SubStepAggregatingScreenshotFinder
+
+import static com.google.inject.name.Names.named
 
 class PersistenceModule extends AbstractModule {
 
@@ -22,6 +27,8 @@ class PersistenceModule extends AbstractModule {
 			bind(LogFinder).to(ScanningLogFinder)
 			bind(HierarchicalLineSkipper).to(RecursiveHierarchicalLineSkipper)
 			bind(LogFilter).to(Log4JDefaultFilter)
+			bind(File).annotatedWith(named("workspace")).toProvider(WorkspaceProvider)
+			bind(TestExecutionConfiguration).to(PersistenceConfiguration)
 		]
 	}
 

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/workspace/WorkspaceProvider.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/persistence/workspace/WorkspaceProvider.xtend
@@ -13,7 +13,7 @@ import org.testeditor.web.dropwizard.auth.User
 
 import static java.nio.charset.StandardCharsets.UTF_8
 
-class WorkspaceProvider {
+class WorkspaceProvider implements Provider<File> {
 
 	static val logger = LoggerFactory.getLogger(WorkspaceProvider)
 
@@ -37,6 +37,10 @@ class WorkspaceProvider {
 		} else {
 			return new File(config.localRepoFileRoot)
 		}
+	}
+
+	override get() {
+		return this.workspace 
 	}
 
 	def File getWorkspaceFile(String resourcePath) {
@@ -112,5 +116,4 @@ class WorkspaceProvider {
 			throw new MaliciousPathException(workspacePath, filePath, userProvider.get.name)
 		}
 	}
-
 }

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionConfiguration.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionConfiguration.xtend
@@ -4,4 +4,5 @@ interface TestExecutionConfiguration {
 	def String getXvfbrunPath()
 	def String getNicePath()
 	def String getShPath()
+	def Boolean getFilterTestSubStepsFromLogs()
 }

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionConfiguration.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionConfiguration.xtend
@@ -1,0 +1,7 @@
+package org.testeditor.web.backend.testexecution
+
+interface TestExecutionConfiguration {
+	def String getXvfbrunPath()
+	def String getNicePath()
+	def String getShPath()
+}

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/loglines/LogLineSelector.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/loglines/LogLineSelector.xtend
@@ -1,10 +1,10 @@
 package org.testeditor.web.backend.testexecution.loglines
 
+import java.io.File
 import java.util.regex.Pattern
 import java.util.stream.Collectors
 import java.util.stream.Stream
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
-import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 import org.testeditor.web.backend.testexecution.TestExecutionKey
 
 import static java.nio.charset.StandardCharsets.UTF_8
@@ -15,7 +15,7 @@ import static extension java.nio.file.Files.lines
 abstract class LogLineSelector {
 
 	protected val TestExecutionKey key
-	protected val extension WorkspaceProvider
+	protected val File workspace
 
 	final def String[] getRelevantLines() {
 		return key.getLogFile(workspace).lines(UTF_8).findStart.findEnd.collect(Collectors.toList)
@@ -44,12 +44,12 @@ class PatternBasedLogLineSelector extends LogLineSelector {
 	val Pattern compiledLeavePattern
 	val LogLineSelector preSelector
 
-	new(TestExecutionKey key, WorkspaceProvider workspaceProvider, String enterPattern, String leavePattern) {
-		this(key, workspaceProvider, enterPattern, leavePattern, new FullLogLineSelector(key, workspaceProvider))
+	new(TestExecutionKey key, File workspace, String enterPattern, String leavePattern) {
+		this(key, workspace, enterPattern, leavePattern, new FullLogLineSelector(key, workspace))
 	}
 
-	new(TestExecutionKey key, WorkspaceProvider workspaceProvider, String enterPattern, String leavePattern, LogLineSelector preSelector) {
-		super(key, workspaceProvider)
+	new(TestExecutionKey key, File workspace, String enterPattern, String leavePattern, LogLineSelector preSelector) {
+		super(key, workspace)
 		this.compiledEnterPattern = Pattern.compile(enterPattern)
 		this.compiledLeavePattern = Pattern.compile(leavePattern)
 		this.preSelector = preSelector

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinder.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinder.xtend
@@ -6,9 +6,9 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Provider
 import org.apache.commons.lang3.Validate
-import org.testeditor.web.backend.persistence.PersistenceConfiguration
-import org.testeditor.web.backend.persistence.util.HierarchicalLineSkipper
+import org.testeditor.web.backend.testexecution.TestExecutionConfiguration
 import org.testeditor.web.backend.testexecution.TestExecutionKey
+import org.testeditor.web.backend.testexecution.util.HierarchicalLineSkipper
 
 /**
  * Locates log files corresponding to test execution keys relying on file naming
@@ -22,7 +22,7 @@ class ScanningLogFinder implements LogFinder {
 	static val ILLEGAL_TEST_EXECUTION_KEY_MESSAGE = "Provided test execution key must contain a test suite id and a test suite run id. (Key was: '%s'.)"
 
 	@Inject @Named("workspace") Provider<File> workspaceProvider
-	@Inject extension PersistenceConfiguration
+	@Inject extension TestExecutionConfiguration
 	@Inject extension HierarchicalLineSkipper
 	@Inject extension LogFilter
 

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinder.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinder.xtend
@@ -1,11 +1,13 @@
 package org.testeditor.web.backend.testexecution.loglines
 
+import java.io.File
 import java.util.regex.Pattern
 import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Provider
 import org.apache.commons.lang3.Validate
 import org.testeditor.web.backend.persistence.PersistenceConfiguration
 import org.testeditor.web.backend.persistence.util.HierarchicalLineSkipper
-import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 import org.testeditor.web.backend.testexecution.TestExecutionKey
 
 /**
@@ -19,23 +21,23 @@ class ScanningLogFinder implements LogFinder {
 	static val ENTER_REGEX = Pattern.compile('''@[A-Z_]+:ENTER:([0-9a-f]+:)?(.+)''')
 	static val ILLEGAL_TEST_EXECUTION_KEY_MESSAGE = "Provided test execution key must contain a test suite id and a test suite run id. (Key was: '%s'.)"
 
-	@Inject extension WorkspaceProvider workspaceProvider
+	@Inject @Named("workspace") Provider<File> workspaceProvider
 	@Inject extension PersistenceConfiguration
 	@Inject extension HierarchicalLineSkipper
 	@Inject extension LogFilter
 
 	private def getLogLineSelector(TestExecutionKey key) {
 		return if (key.caseRunId.nullOrEmpty) {
-			new FullLogLineSelector(key, workspaceProvider)
+			new FullLogLineSelector(key, workspaceProvider.get)
 		} else {
-			val testCaseSelector = new PatternBasedLogLineSelector(key, workspaceProvider, //
+			val testCaseSelector = new PatternBasedLogLineSelector(key, workspaceProvider.get, //
 			'''@TESTRUN:ENTER:«key.suiteId».«key.suiteRunId».«key.caseRunId»''', //
 			'''@TESTRUN:LEAVE:«key.suiteId».«key.suiteRunId».«key.caseRunId»''')
 
 			if (key.callTreeId.nullOrEmpty) {
 				testCaseSelector
 			} else {
-				new PatternBasedLogLineSelector(key, workspaceProvider, //
+				new PatternBasedLogLineSelector(key, workspaceProvider.get, //
 				'''@[A-Z_]+:ENTER:[0-9a-f]+:«key.callTreeId»''', //
 				'''@[A-Z_]+:LEAVE:[0-9a-f]+:«key.callTreeId»''', //
 				testCaseSelector)

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/screenshots/TestArtifactRegistryScreenshotFinder.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/screenshots/TestArtifactRegistryScreenshotFinder.xtend
@@ -1,11 +1,13 @@
 package org.testeditor.web.backend.testexecution.screenshots
 
+import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.regex.Pattern
 import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Provider
 import org.slf4j.LoggerFactory
-import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 import org.testeditor.web.backend.testexecution.TestExecutionKey
 
 import static java.nio.charset.StandardCharsets.UTF_8
@@ -14,7 +16,7 @@ import static extension java.nio.file.Files.*
 
 class TestArtifactRegistryScreenshotFinder implements ScreenshotFinder {
 
-	@Inject extension WorkspaceProvider
+	@Inject @Named("workspace") Provider<File> workspace
 
 	static val logger = LoggerFactory.getLogger(TestArtifactRegistryScreenshotFinder)
 
@@ -34,7 +36,7 @@ class TestArtifactRegistryScreenshotFinder implements ScreenshotFinder {
 	}
 
 	private def Path getArtifactRegistryPath() {
-		return workspace.absoluteFile.toPath.resolve(Paths.get(BASE_PATH))
+		return workspace.get.absoluteFile.toPath.resolve(Paths.get(BASE_PATH))
 	}
 
 	private def toPath(TestExecutionKey key) {

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/util/HierarchicalLineSkipper.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/util/HierarchicalLineSkipper.xtend
@@ -1,4 +1,4 @@
-package org.testeditor.web.backend.persistence.util
+package org.testeditor.web.backend.testexecution.util
 
 import java.util.function.Function
 import java.util.regex.Matcher

--- a/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/util/RecursiveHierarchicalLineSkipper.xtend
+++ b/org.testeditor.web.backend.persistence/src/main/java/org/testeditor/web/backend/testexecution/util/RecursiveHierarchicalLineSkipper.xtend
@@ -1,11 +1,11 @@
-package org.testeditor.web.backend.persistence.util
+package org.testeditor.web.backend.testexecution.util
 
 import java.util.function.Function
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import org.eclipse.xtend.lib.annotations.Accessors
 
-import static org.testeditor.web.backend.persistence.util.HierarchicalLineSkipper.EndMarkerRequest.*
+import static org.testeditor.web.backend.testexecution.util.HierarchicalLineSkipper.EndMarkerRequest.*
 
 class RecursiveHierarchicalLineSkipper implements HierarchicalLineSkipper {
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/CancelledTestExecutionDetailsIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/CancelledTestExecutionDetailsIntegrationTest.xtend
@@ -24,7 +24,7 @@ import static javax.ws.rs.core.Response.Status.*
 import static extension java.nio.file.Files.lines
 import static extension java.nio.file.Files.list
 
-class CancelledTestExecutionDetailsTest extends AbstractPersistenceIntegrationTest {
+class CancelledTestExecutionDetailsIntegrationTest extends AbstractPersistenceIntegrationTest {
 
 	static val WORKSPACE_DIR = 'src/test/resources/cancelled-test-execution-details-bug'
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/CancelledTestExecutionDetailsTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/CancelledTestExecutionDetailsTest.xtend
@@ -1,4 +1,4 @@
-package org.testeditor.web.backend.testexecution
+package org.testeditor.web.backend.persistence
 
 import java.io.File
 import java.io.IOException
@@ -14,7 +14,7 @@ import javax.ws.rs.core.MediaType
 import org.eclipse.jgit.api.Git
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.junit.Test
-import org.testeditor.web.backend.persistence.AbstractPersistenceIntegrationTest
+import org.testeditor.web.backend.testexecution.TestExecutionKey
 
 import static java.nio.charset.StandardCharsets.UTF_8
 import static java.util.concurrent.TimeUnit.MINUTES

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/TestSuiteExecutorIntegrationTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/persistence/TestSuiteExecutorIntegrationTest.xtend
@@ -1,4 +1,4 @@
-package org.testeditor.web.backend.testexecution
+package org.testeditor.web.backend.persistence
 
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -14,7 +14,8 @@ import javax.ws.rs.core.MediaType
 import org.assertj.core.api.SoftAssertions
 import org.eclipse.jgit.junit.JGitTestUtil
 import org.junit.Test
-import org.testeditor.web.backend.persistence.AbstractPersistenceIntegrationTest
+import org.testeditor.web.backend.testexecution.TestExecutionKey
+import org.testeditor.web.backend.testexecution.TestExecutorProvider
 
 import static javax.ws.rs.core.Response.Status.*
 import static org.assertj.core.api.Assertions.*

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/ConsecutiveTestExecutionsWithChangesTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/ConsecutiveTestExecutionsWithChangesTest.xtend
@@ -1,6 +1,7 @@
 package org.testeditor.web.backend.testexecution
 
 import java.io.File
+import javax.inject.Provider
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
 import org.junit.After
@@ -11,7 +12,6 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.testeditor.web.backend.persistence.PersistenceConfiguration
-import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 
 import static java.nio.charset.StandardCharsets.UTF_8
 import static java.util.concurrent.TimeUnit.SECONDS
@@ -24,7 +24,7 @@ class ConsecutiveTestExecutionsWithChangesTest {
 	static val TESTFILE_PATH = 'src/test/java/sample/SampleTest.tcl'
 	static val BACKUP_FILE = new File('SampleTest.tcl.bak') 
 	
-	@Mock WorkspaceProvider mockWorkspaceProvider
+	@Mock Provider<File> mockWorkspaceProvider
 	@Mock PersistenceConfiguration mockConfig
 	@InjectMocks TestExecutorProvider executorUnderTest
 	
@@ -48,7 +48,7 @@ class ConsecutiveTestExecutionsWithChangesTest {
 	def void consecutiveTestExecutionAfterChangeTest() {
 		// given
 		val workspace = new File(WORKSPACE_DIR)
-		when(mockWorkspaceProvider.workspace).thenReturn(workspace)
+		when(mockWorkspaceProvider.get).thenReturn(workspace)
 		val testClass = 'sample.SampleTest'
 		val firstTestKey = new TestExecutionKey('0', '0')
 		val secondTestKey = new TestExecutionKey('0', '1')	

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/ConsecutiveTestExecutionsWithChangesTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/ConsecutiveTestExecutionsWithChangesTest.xtend
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.testeditor.web.backend.persistence.PersistenceConfiguration
 
 import static java.nio.charset.StandardCharsets.UTF_8
 import static java.util.concurrent.TimeUnit.SECONDS
@@ -25,7 +24,7 @@ class ConsecutiveTestExecutionsWithChangesTest {
 	static val BACKUP_FILE = new File('SampleTest.tcl.bak') 
 	
 	@Mock Provider<File> mockWorkspaceProvider
-	@Mock PersistenceConfiguration mockConfig
+	@Mock TestExecutionConfiguration mockConfig
 	@InjectMocks TestExecutorProvider executorUnderTest
 	
 	@Before

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorProviderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorProviderTest.xtend
@@ -3,9 +3,11 @@ package org.testeditor.web.backend.testexecution
 import java.time.Instant
 import org.junit.Test
 import org.mockito.InjectMocks
-import org.testeditor.web.backend.persistence.AbstractPersistenceTest
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
 
-class TestExecutorProviderTest extends AbstractPersistenceTest {
+@RunWith(MockitoJUnitRunner)
+class TestExecutorProviderTest {
 
 	@InjectMocks TestExecutorProvider testExecutorProviderUnderTest
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorTest.xtend
@@ -5,7 +5,9 @@ import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.spi.LoggingEvent
 import ch.qos.logback.core.Appender
+import java.io.File
 import java.util.regex.Pattern
+import javax.inject.Provider
 import org.assertj.core.api.Condition
 import org.junit.Assert
 import org.junit.Before
@@ -20,7 +22,6 @@ import org.mockito.Mockito
 import org.slf4j.LoggerFactory
 import org.testeditor.web.backend.persistence.AbstractPersistenceTest
 import org.testeditor.web.backend.persistence.PersistenceConfiguration
-import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 
 import static org.assertj.core.api.Assertions.*
 import static org.mockito.Mockito.*
@@ -31,14 +32,14 @@ class TestExecutorTest extends AbstractPersistenceTest {
 
 	@InjectMocks TestExecutorProvider testExecutorProviderUnderTest
 
-	@Mock WorkspaceProvider workspaceProviderMock
+	@Mock Provider<File> workspaceProviderMock
 	@Mock PersistenceConfiguration config
 	@Mock Appender<ILoggingEvent> logAppender
 	@Captor ArgumentCaptor<LoggingEvent> logCaptor
 
 	@Before
 	def void setupWorkspaceProviderMock() {
-		Mockito.when(workspaceProviderMock.workspace).thenReturn(temporaryFolder.root)
+		Mockito.when(workspaceProviderMock.get).thenReturn(temporaryFolder.root)
 	}
 
 	@Before

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorTest.xtend
@@ -14,26 +14,27 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
 import org.slf4j.LoggerFactory
-import org.testeditor.web.backend.persistence.AbstractPersistenceTest
-import org.testeditor.web.backend.persistence.PersistenceConfiguration
 
 import static org.assertj.core.api.Assertions.*
 import static org.mockito.Mockito.*
 
-class TestExecutorTest extends AbstractPersistenceTest {
+@RunWith(MockitoJUnitRunner)
+class TestExecutorTest {
 
 	@Rule public val temporaryFolder = new TemporaryFolder
 
 	@InjectMocks TestExecutorProvider testExecutorProviderUnderTest
 
 	@Mock Provider<File> workspaceProviderMock
-	@Mock PersistenceConfiguration config
+	@Mock TestExecutionConfiguration config
 	@Mock Appender<ILoggingEvent> logAppender
 	@Captor ArgumentCaptor<LoggingEvent> logCaptor
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestLogWriterTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestLogWriterTest.xtend
@@ -11,15 +11,17 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Spy
-import org.testeditor.web.backend.persistence.AbstractPersistenceTest
+import org.mockito.junit.MockitoJUnitRunner
 
 import static java.nio.charset.StandardCharsets.UTF_8
 import static org.mockito.Mockito.when
 
-class TestLogWriterTest extends AbstractPersistenceTest {
+@RunWith(MockitoJUnitRunner)
+class TestLogWriterTest {
 
 	@InjectMocks TestLogWriter writerUnderTest
 	@Spy MockExecutor executor

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestStatusMapperTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/TestStatusMapperTest.xtend
@@ -3,21 +3,19 @@ package org.testeditor.web.backend.testexecution
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import javax.inject.Inject
 import org.junit.Test
-import org.testeditor.web.backend.persistence.AbstractPersistenceTest
 
 import static org.assertj.core.api.Assertions.*
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
 import static org.testeditor.web.backend.testexecution.TestStatus.*
 
-class TestStatusMapperTest extends AbstractPersistenceTest {
+class TestStatusMapperTest {
 
 	static val EXIT_SUCCESS = 0;
 	static val EXIT_FAILURE = 1;
 
-	@Inject TestStatusMapper statusMapperUnderTest
+	TestStatusMapper statusMapperUnderTest = new TestStatusMapper
 	
 	extension TestProcessMocking = new TestProcessMocking
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinderTest.xtend
@@ -13,9 +13,9 @@ import org.mockito.Mock
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
 import org.testeditor.web.backend.persistence.PersistenceConfiguration
-import org.testeditor.web.backend.persistence.util.HierarchicalLineSkipper
-import org.testeditor.web.backend.persistence.util.RecursiveHierarchicalLineSkipper
 import org.testeditor.web.backend.testexecution.TestExecutionKey
+import org.testeditor.web.backend.testexecution.util.HierarchicalLineSkipper
+import org.testeditor.web.backend.testexecution.util.RecursiveHierarchicalLineSkipper
 
 import static java.nio.charset.StandardCharsets.UTF_8
 import static org.assertj.core.api.Assertions.assertThat

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinderTest.xtend
@@ -1,7 +1,9 @@
 package org.testeditor.web.backend.testexecution.loglines
 
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
+import javax.inject.Provider
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -13,7 +15,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.testeditor.web.backend.persistence.PersistenceConfiguration
 import org.testeditor.web.backend.persistence.util.HierarchicalLineSkipper
 import org.testeditor.web.backend.persistence.util.RecursiveHierarchicalLineSkipper
-import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 import org.testeditor.web.backend.testexecution.TestExecutionKey
 
 import static java.nio.charset.StandardCharsets.UTF_8
@@ -99,7 +100,7 @@ class ScanningLogFinderTest {
 
 	@Rule public val TemporaryFolder testRoot = new TemporaryFolder
 
-	@Mock WorkspaceProvider mockWorkspace
+	@Mock Provider<File> mockWorkspace
 	@Mock PersistenceConfiguration mockConfig
 	@Spy HierarchicalLineSkipper lineSkipper = new RecursiveHierarchicalLineSkipper
 	@Mock LogFilter mockLogFilter
@@ -119,7 +120,7 @@ class ScanningLogFinderTest {
 		val arbitraryDateAndTime = '20180716111612603'
 		when(mockConfig.filterTestSubStepsFromLogs).thenReturn(true)
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val logPath = testRoot.newFolder('logs').toPath
 		val logFile = logPath.resolve('''testrun.0-0--.«arbitraryDateAndTime».log''')
 		Files.copy(SAMPLE_LOG_FILE_PATH, logFile)
@@ -159,7 +160,7 @@ class ScanningLogFinderTest {
 		val arbitraryDateAndTime = '20180716111612603'
 		when(mockConfig.filterTestSubStepsFromLogs).thenReturn(true)
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val logPath = testRoot.newFolder('logs').toPath
 		val logFile = logPath.resolve('''testrun.0-0--.«arbitraryDateAndTime».log''')
 		Files.copy(SAMPLE_LOG_FILE_PATH, logFile)
@@ -186,7 +187,7 @@ class ScanningLogFinderTest {
 		val arbitraryDateAndTime = '20180716111612603'
 		when(mockConfig.filterTestSubStepsFromLogs).thenReturn(true)
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val logPath = testRoot.newFolder('logs').toPath
 		val logFile = logPath.resolve('''testrun.0-0--.«arbitraryDateAndTime».log''')
 		Files.copy(SAMPLE_LOG_FILE_PATH, logFile)
@@ -210,7 +211,7 @@ class ScanningLogFinderTest {
 		val arbitraryDateAndTime = '20180716111612603'
 		when(mockConfig.filterTestSubStepsFromLogs).thenReturn(false)
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val logPath = testRoot.newFolder('logs').toPath
 		val logFile = logPath.resolve('''testrun.0-0--.«arbitraryDateAndTime».log''')
 		Files.copy(SAMPLE_LOG_FILE_PATH, logFile)
@@ -232,7 +233,7 @@ class ScanningLogFinderTest {
 		val arbitraryDateAndTime = '20180716111612603'
 		when(mockConfig.filterTestSubStepsFromLogs).thenReturn(true)
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val logPath = testRoot.newFolder('logs').toPath
 		val logFile = logPath.resolve('''testrun.0-0--.«arbitraryDateAndTime».log''')
 		Files.copy(SAMPLE_LOG_FILE_PATH, logFile)
@@ -251,7 +252,7 @@ class ScanningLogFinderTest {
 		val arbitraryDateAndTime = '20180716111612603'
 		when(mockConfig.filterTestSubStepsFromLogs).thenReturn(true)
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val logPath = testRoot.newFolder('logs').toPath
 		val logFile = logPath.resolve('''testrun.0-0--.«arbitraryDateAndTime».log''')
 		Files.copy(SAMPLE_LOG_FILE_PATH, logFile)
@@ -316,7 +317,7 @@ class ScanningLogFinderTest {
 		val arbitraryDateAndTime = '20180716111612603'
 		when(mockConfig.filterTestSubStepsFromLogs).thenReturn(false)
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val logPath = testRoot.newFolder('logs').toPath
 		val logFile = logPath.resolve('''testrun.0-0--.«arbitraryDateAndTime».log''')
 		Files.copy(SAMPLE_LOG_FILE_PATH, logFile)
@@ -337,7 +338,7 @@ class ScanningLogFinderTest {
 		val arbitraryDateAndTime = '20180716111612603'
 		when(mockConfig.filterTestSubStepsFromLogs).thenReturn(false)
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val logPath = testRoot.newFolder('logs').toPath
 		val logFile = logPath.resolve('''testrun.0-0--.«arbitraryDateAndTime».log''')
 		Files.copy(SAMPLE_LOG_FILE_PATH, logFile)
@@ -359,7 +360,7 @@ class ScanningLogFinderTest {
 
 		when(mockConfig.filterTestSubStepsFromLogs).thenReturn(true)
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val logPath = testRoot.newFolder('logs').toPath
 		val logFile = logPath.resolve('''testrun.0-0--.«arbitraryDateAndTime».log''')
 		Files.copy(SAMPLE_LOG_FILE_PATH, logFile)

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/loglines/ScanningLogFinderTest.xtend
@@ -12,7 +12,6 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
-import org.testeditor.web.backend.persistence.PersistenceConfiguration
 import org.testeditor.web.backend.testexecution.TestExecutionKey
 import org.testeditor.web.backend.testexecution.util.HierarchicalLineSkipper
 import org.testeditor.web.backend.testexecution.util.RecursiveHierarchicalLineSkipper
@@ -26,6 +25,7 @@ import static org.mockito.ArgumentMatchers.matches
 import static org.mockito.Mockito.when
 
 import static extension java.nio.file.Files.readAllLines
+import org.testeditor.web.backend.testexecution.TestExecutionConfiguration
 
 @RunWith(MockitoJUnitRunner)
 class ScanningLogFinderTest {
@@ -101,7 +101,7 @@ class ScanningLogFinderTest {
 	@Rule public val TemporaryFolder testRoot = new TemporaryFolder
 
 	@Mock Provider<File> mockWorkspace
-	@Mock PersistenceConfiguration mockConfig
+	@Mock TestExecutionConfiguration mockConfig
 	@Spy HierarchicalLineSkipper lineSkipper = new RecursiveHierarchicalLineSkipper
 	@Mock LogFilter mockLogFilter
 

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/screenshots/TestArtifactRegistryScreenshotFinderTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/screenshots/TestArtifactRegistryScreenshotFinderTest.xtend
@@ -1,5 +1,7 @@
 package org.testeditor.web.backend.testexecution.screenshots
 
+import java.io.File
+import javax.inject.Provider
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -7,7 +9,6 @@ import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.testeditor.web.backend.persistence.workspace.WorkspaceProvider
 import org.testeditor.web.backend.testexecution.TestExecutionKey
 
 import static java.nio.charset.StandardCharsets.UTF_8
@@ -21,7 +22,7 @@ class TestArtifactRegistryScreenshotFinderTest {
 
 	@Rule public val TemporaryFolder testRoot = new TemporaryFolder
 
-	@Mock WorkspaceProvider mockWorkspace
+	@Mock Provider<File> mockWorkspace
 
 	@InjectMocks
 	TestArtifactRegistryScreenshotFinder screenshotFinder
@@ -32,7 +33,7 @@ class TestArtifactRegistryScreenshotFinderTest {
 		val key = new TestExecutionKey('0', '1', '2', '3')
 		val expectedScreenshotPath = 'screenshots/test4711/weird_name_for_a_screenshot.png'
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val testCasePath = testRoot.newFolder('.testexecution', 'artifacts', '0', '1', '2').toPath
 		val artifactRegistryFile = testCasePath.resolve('3.yaml')
 		artifactRegistryFile.write(#['''"screenshot": "«expectedScreenshotPath»"'''], UTF_8)
@@ -54,7 +55,7 @@ class TestArtifactRegistryScreenshotFinderTest {
 			'screenshots/and/even/a-3rd-one.png'
 		]
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val testCasePath = testRoot.newFolder('.testexecution', 'artifacts', '0', '1', '2').toPath
 		val artifactRegistryFile = testCasePath.resolve('3.yaml')
 		artifactRegistryFile.write(expectedScreenshotPaths.map['''"screenshot": "«it»"'''], UTF_8)
@@ -75,7 +76,7 @@ class TestArtifactRegistryScreenshotFinderTest {
 			'screenshots/and/even/a-3rd-one.png'
 		]
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 		val testCasePath = testRoot.newFolder('.testexecution', 'artifacts', '0', '1', '2').toPath
 		val artifactRegistryFile = testCasePath.resolve('3.yaml')
 		artifactRegistryFile.write(#[
@@ -94,7 +95,7 @@ class TestArtifactRegistryScreenshotFinderTest {
 		// given
 		val key = new TestExecutionKey('0', '1', '2', '3')
 
-		when(mockWorkspace.workspace).thenReturn(testRoot.root)
+		when(mockWorkspace.get).thenReturn(testRoot.root)
 
 		// when
 		val actualScreenshotPaths = screenshotFinder.getScreenshotPathsForTestStep(key)

--- a/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/util/RecursiveHierarchicalLineSkipperTest.xtend
+++ b/org.testeditor.web.backend.persistence/src/test/java/org/testeditor/web/backend/testexecution/util/RecursiveHierarchicalLineSkipperTest.xtend
@@ -1,9 +1,9 @@
-package org.testeditor.web.backend.persistence.util
+package org.testeditor.web.backend.testexecution.util
 
 import java.util.function.Function
 import java.util.regex.Pattern
 import org.junit.Test
-import org.testeditor.web.backend.persistence.util.HierarchicalLineSkipper.EndMarkerRequest
+import org.testeditor.web.backend.testexecution.util.HierarchicalLineSkipper.EndMarkerRequest
 
 import static org.assertj.core.api.Assertions.*
 


### PR DESCRIPTION
some small refactorings to properly decouple test execution code from the rest. Prerequisite for taking out test execution into its own repository w/ separate packaging and releasing.