### PR TITLE
add missing property to configure local repo location

### DIFF
--- a/org.testeditor.web.backend.persistence/config.template.yml
+++ b/org.testeditor.web.backend.persistence/config.template.yml
@@ -1,3 +1,4 @@
+localRepoFileRoot: %REPO_ROOT%
 remoteRepoUrl: %TARGET_REPO%
 branchName: %BRANCH_NAME%
 privateKeyLocation: %KEY_LOCATION%


### PR DESCRIPTION
... without this line, PBE always falls back to the default of checking out user workspaces in `repo`, relative to the working directory. `%REPO_ROOT%` will be replaced by the value of the corresponding environment variable, `REPO_ROOT`, during startup of PBE: https://github.com/test-editor/test-editor-backend/blob/5fc26b47ce120af3db8116ea178559abb2a1affc/org.testeditor.web.backend.persistence/run.sh#L84