### PR TITLE
Feature/work dir

### DIFF
--- a/org.testeditor.web.backend.persistence/Dockerfile
+++ b/org.testeditor.web.backend.persistence/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:10-jdk
 
-# This image needs six environment variables upon execution:
+# This image needs five environment variables upon execution:
 # * TARGET_REPO
 #   Defines the git repository used
 # * BRANCH_NAME
@@ -12,15 +12,12 @@ FROM openjdk:10-jdk
 # * REPO_MODE
 #   mode in which the repositories are to be used, valid values are: 'pullOnly', 'pullPush'
 #   pull only will never push back changes to the remote repo (local changes are possible)
-# * WORK_DIR
-#   Working directory of the Java server process. User workspaces will be relative to this directory.
-#   It will also contain the Gradle cache, and other files written after startup. 
 
 LABEL license="EPL 1.0" \
       name="testeditor/persistence"
 
 ENV PROG_DIR=/opt/testeditor \
-    REPO_ROOT=/repo \
+    WORK_DIR=/workdir \
     JAVA_TOOL_OPTIONS="-Djdk.http.auth.tunneling.disabledSchemes=" \
     FIREFOX_VERSION="latest" \
     FIREFOX_SOURCE_URL="https://download.mozilla.org/?product=firefox-latest&lang=en-US&os=linux64" \
@@ -52,13 +49,13 @@ RUN \
     useradd -u 5555 -r -g testeditor -G root -d ${PROG_DIR} -s /sbin/nologin -c "service user" testeditor && \
     \
     mkdir -p ${PROG_DIR} && \
-    mkdir -p ${REPO_ROOT} && \
+    mkdir -p ${WORK_DIR} && \
     mkdir -p /tmp/.X11-unix && \
     \
     chmod --recursive ug+rwX,o-rwX ${PROG_DIR} && \
     chown --recursive testeditor:root ${PROG_DIR} && \
-    chmod --recursive ug+rw,o-rwX ${REPO_ROOT} && \
-    chown --recursive testeditor:root ${REPO_ROOT} && \
+    chmod --recursive ug+rw,o-rwX ${WORK_DIR} && \
+    chown --recursive testeditor:root ${WORK_DIR} && \
     chmod --recursive 1777 /tmp/.X11-unix
 
 # group testeditor:

--- a/org.testeditor.web.backend.persistence/Dockerfile
+++ b/org.testeditor.web.backend.persistence/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:10-jdk
 
-# This image needs five environment variables upon execution:
+# This image needs six environment variables upon execution:
 # * TARGET_REPO
 #   Defines the git repository used
 # * BRANCH_NAME
@@ -10,14 +10,16 @@ FROM openjdk:10-jdk
 # * KNOWN_HOSTS
 #   file location of the known hosts file to be used for network access
 # * REPO_MODE
-#   mode in which the repositorys to be used, valid values are: 'pullOnly', 'pullPush'
+#   mode in which the repositories are to be used, valid values are: 'pullOnly', 'pullPush'
 #   pull only will never push back changes to the remote repo (local changes are possible)
+# * WORK_DIR
+#   Working directory of the Java server process. User workspaces will be relative to this directory.
+#   It will also contain the Gradle cache, and other files written after startup. 
 
 LABEL license="EPL 1.0" \
       name="testeditor/persistence"
 
 ENV PROG_DIR=/opt/testeditor \
-    GRADLE_USER_HOME=/opt/testeditor/.gradle \
     REPO_ROOT=/repo \
     JAVA_TOOL_OPTIONS="-Djdk.http.auth.tunneling.disabledSchemes=" \
     FIREFOX_VERSION="latest" \
@@ -52,8 +54,6 @@ RUN \
     mkdir -p ${PROG_DIR} && \
     mkdir -p ${REPO_ROOT} && \
     mkdir -p /tmp/.X11-unix && \
-    \
-    mv ${PROG_DIR}/config.template.yml ${PROG_DIR}/config.yml &&\
     \
     chmod --recursive ug+rwX,o-rwX ${PROG_DIR} && \
     chown --recursive testeditor:root ${PROG_DIR} && \

--- a/org.testeditor.web.backend.persistence/config.template.yml
+++ b/org.testeditor.web.backend.persistence/config.template.yml
@@ -1,3 +1,4 @@
+localRepoFileRoot: %REPO_ROOT%
 remoteRepoUrl: %TARGET_REPO%
 branchName: %BRANCH_NAME%
 privateKeyLocation: %KEY_LOCATION%

--- a/org.testeditor.web.backend.persistence/run.sh
+++ b/org.testeditor.web.backend.persistence/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd $WORK_DIR
+
 if [ "$BRANCH_NAME" == "" ]; then
   export BRANCH_NAME="master"
 fi
@@ -14,14 +16,15 @@ fi
 
 # Additional options to be passed to the JVM can be provided via the
 # TE_JAVA_OPTIONS environment variable
-export JAVA_TOOL_OPTIONS="${TE_JAVA_OPTIONS} -Djavax.net.ssl.trustStorePassword=changeit -Djavax.net.ssl.trustStore=${PROG_DIR}/testeditor.certs"
-keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore ${PROG_DIR}/testeditor.certs -srcstorepass changeit -deststorepass changeit -noprompt
+export JAVA_TOOL_OPTIONS="${TE_JAVA_OPTIONS} -Djavax.net.ssl.trustStorePassword=changeit -Djavax.net.ssl.trustStore=${WORK_DIR}/testeditor.certs"
+keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore ${WORK_DIR}/testeditor.certs -srcstorepass changeit -deststorepass changeit -noprompt
 if [ "$PROXY_CERT" != "" ]; then
   echo "importing certificate into java certificate store"
-  keytool -importcert -file $PROXY_CERT -keystore ${PROG_DIR}/testeditor.certs -storepass changeit -noprompt -trustcacerts
+  keytool -importcert -file $PROXY_CERT -keystore ${WORK_DIR}/testeditor.certs -storepass changeit -noprompt -trustcacerts
 fi
 
-GRADLE_PROPS_TARGET_FILE=${PROG_DIR}/.gradle/gradle.properties
+export GRADLE_USER_HOME=$WORK_DIR/.gradle
+GRADLE_PROPS_TARGET_FILE=$GRADLE_USER_HOME/gradle.properties
 if [ "$GRADLE_PROPS_CONTENT" != "" ]; then
   echo "using gradle properties with content passed through env"
   mkdir -p `dirname $GRADLE_PROPS_TARGET_FILE`
@@ -45,15 +48,15 @@ fi
 
 if [ "$GIT_PRIVATE_KEY" != "" ]; then
   echo "configuring private key for repo access"
-  KEY_LOCATION=${PROG_DIR}/ssh-keys/ssh-privatekey
+  KEY_LOCATION=${WORK_DIR}/ssh-keys/ssh-privatekey
   mkdir -p `dirname $KEY_LOCATION`
   echo "$GIT_PRIVATE_KEY" > $KEY_LOCATION
   chmod 600 $KEY_LOCATION
   sha1sum $KEY_LOCATION
 fi
 
-KNOWN_HOSTS_FILE=${PROG_DIR}/ssh-keys/known_hosts
-mkdir -p ${PROG_DIR}/ssh-keys
+KNOWN_HOSTS_FILE=${WORK_DIR}/ssh-keys/known_hosts
+mkdir -p ${WORK_DIR}/ssh-keys
 if [ "$KNOWN_HOSTS" != "" ]; then
   echo "copying passed known_hosts file from $KNOWN_HOSTS"
   cp $KNOWN_HOSTS $KNOWN_HOSTS_FILE
@@ -79,16 +82,18 @@ mv TEMP $KNOWN_HOSTS_FILE
 echo "using known hosts:"
 cat $KNOWN_HOSTS_FILE
 
-sed -i "s|%REPO_MODE%|$REPO_MODE|g" config.yml
-sed -i "s|%TARGET_REPO%|$TARGET_REPO|g" config.yml
-sed -i "s|%REPO_ROOT%|$REPO_ROOT|g" config.yml
-sed -i "s|%BRANCH_NAME%|$BRANCH_NAME|g" config.yml
-sed -i "s|%API_TOKEN_SECRET%|$API_TOKEN_SECRET|g" config.yml
-sed -i "s|%KEY_LOCATION%|$KEY_LOCATION|g" config.yml
-sed -i "s|%KNOWN_HOSTS%|$KNOWN_HOSTS_FILE|g" config.yml
+cp $PROG_DIR/config.template.yml $WORK_DIR/config.yml
+sed -i "s|%REPO_MODE%|$REPO_MODE|g" $WORK_DIR/config.yml
+sed -i "s|%TARGET_REPO%|$TARGET_REPO|g" $WORK_DIR/config.yml
+sed -i "s|%REPO_ROOT%|$REPO_ROOT|g" $WORK_DIR/config.yml
+sed -i "s|%BRANCH_NAME%|$BRANCH_NAME|g" $WORK_DIR/config.yml
+sed -i "s|%API_TOKEN_SECRET%|$API_TOKEN_SECRET|g" $WORK_DIR/config.yml
+sed -i "s|%KEY_LOCATION%|$KEY_LOCATION|g" $WORK_DIR/config.yml
+sed -i "s|%KNOWN_HOSTS%|$KNOWN_HOSTS_FILE|g" $WORK_DIR/config.yml
 
 export HOME=/opt/testeditor
 
 export DISPLAY=:99.0
 
-exec bin/org.testeditor.web.backend.persistence server config.yml
+cd $WORK_DIR
+exec $PROG_DIR/bin/org.testeditor.web.backend.persistence server $WORK_DIR/config.yml

--- a/org.testeditor.web.backend.persistence/run.sh
+++ b/org.testeditor.web.backend.persistence/run.sh
@@ -2,6 +2,8 @@
 
 cd $WORK_DIR
 
+export REPO_ROOT="$WORK_DIR/repo"
+
 if [ "$BRANCH_NAME" == "" ]; then
   export BRANCH_NAME="master"
 fi


### PR DESCRIPTION
This introduces a ~configurable~ working directory for the persistence backend, which is separate from the program directory at `/opt/testeditor`. It is hard-wired to `/workdir`. The Java server process will be run from the working directory. Files written to disk before that (Dropwizard's config.yml, ssh keys, custom Java trust store etc.) will also go into the working directory.
This way, the PBE can be deployed with a dedicated volume mounted in the working directory, to avoid writing into the container's own file system.

~**Note:** this change will break existing deployments, because the `WORK_DIR` environment variable must be set at deployment time. The [tutorials](https://github.com/test-editor/tutorials) will have to be adapted, accordingly, for example.~

**Note 2:** this PR includes #171. Together, these changes achieve that most data written by a running persistence backend will go into the configured working directory. What remains is the following:
* unless the global temp directory (`/tmp`) is reconfigured, the JVM itself and the Gradle workers may still write files into this location.
    * The JVM can be stopped from writing `hsperfdata` by including `-XX:-UsePerfData` in `TE_JAVA_OPTIONS` at deployment time.
* Because `/opt/testeditor` remains the home directory, some stuff ends up there (so it might be best to move the user's home to the working directory, as well):
    * the Maven local repository is still being created at `/opt/testeditor/.m2`
    * Firefox writes to `/opt/testeditor/.mozilla`
    * Firefox, and potentially some other culprits (dconf, fontconfig?) write to `/opt/testeditor/.cache`